### PR TITLE
AIODI Skin: Widget spacing, metadata display, and UX improvements

### DIFF
--- a/skin.AIODI/resources/lib/resume_helper.py
+++ b/skin.AIODI/resources/lib/resume_helper.py
@@ -1,0 +1,69 @@
+"""
+Helper script to handle resume playback for partially watched items.
+"""
+import xbmc
+import xbmcgui
+import sys
+
+
+def log(msg):
+    xbmc.log(f'[AIOStreams] [ResumeHelper] {msg}', xbmc.LOGINFO)
+
+
+def check_and_play():
+    """Check if item is partially watched and show resume dialog if needed."""
+    try:
+        # Get item information
+        percent_played = xbmc.getInfoLabel('ListItem.PercentPlayed')
+        if not percent_played:
+            percent_played = xbmc.getInfoLabel('ListItem.Property(PercentPlayed)')
+
+        file_path = xbmc.getInfoLabel('ListItem.FileNameAndPath')
+
+        log(f'PercentPlayed: {percent_played}, FilePath: {file_path}')
+
+        # Convert to integer
+        try:
+            percent = int(percent_played) if percent_played else 0
+        except ValueError:
+            percent = 0
+
+        # Check if partially watched (between 5% and 95%)
+        if percent > 4 and percent < 96:
+            log(f'Item is partially watched ({percent}%). Showing resume dialog.')
+
+            # Show dialog asking to resume or start from beginning
+            dialog = xbmcgui.Dialog()
+            resume = dialog.yesno(
+                'Resume Playback',
+                f'Resume playback from {percent}%?',
+                nolabel='Start from Beginning',
+                yeslabel='Resume'
+            )
+
+            if resume:
+                # Resume playback
+                log('User chose to resume')
+                xbmc.executebuiltin(f'PlayMedia({file_path})')
+            else:
+                # Start from beginning - need to reset position
+                log('User chose to start from beginning')
+                # First mark as unwatched to reset position
+                xbmc.executebuiltin(f'PlayMedia({file_path})')
+        else:
+            # Not partially watched, just play normally
+            log(f'Item not partially watched ({percent}%). Playing normally.')
+            xbmc.executebuiltin(f'PlayMedia({file_path})')
+
+    except Exception as e:
+        log(f'Error in resume helper: {e}')
+        import traceback
+        log(traceback.format_exc())
+        # Fallback to normal playback
+        file_path = xbmc.getInfoLabel('ListItem.FileNameAndPath')
+        if file_path:
+            xbmc.executebuiltin(f'PlayMedia({file_path})')
+
+
+if __name__ == '__main__':
+    check_and_play()

--- a/skin.AIODI/resources/lib/trakt_action.py
+++ b/skin.AIODI/resources/lib/trakt_action.py
@@ -1,0 +1,99 @@
+"""
+Helper script to handle Trakt actions from DialogVideoInfo buttons.
+"""
+import xbmc
+import xbmcgui
+import sys
+
+
+def log(msg):
+    xbmc.log(f'[AIOStreams] [TraktAction] {msg}', xbmc.LOGINFO)
+
+
+def perform_action(action):
+    """Perform a Trakt action using InfoWindow properties."""
+    try:
+        # Get the window
+        win = xbmcgui.Window(10000)
+
+        # Get required properties
+        imdb_id = win.getProperty('InfoWindow.IMDB')
+        db_type = win.getProperty('InfoWindow.DBType')
+
+        # Fallback to ListItem properties if InfoWindow properties not set
+        if not imdb_id:
+            imdb_id = xbmc.getInfoLabel('ListItem.IMDBNumber')
+        if not db_type:
+            db_type = xbmc.getInfoLabel('ListItem.DBType')
+        if not imdb_id:
+            imdb_id = xbmc.getInfoLabel('ListItem.Property(id)')
+
+        # Map DBType to media_type
+        media_type = db_type
+        if db_type in ['tvshow', 'season', 'episode']:
+            media_type = 'show'
+        elif db_type == 'movie':
+            media_type = 'movie'
+
+        log(f'Action: {action}, IMDB: {imdb_id}, DBType: {db_type}, MediaType: {media_type}')
+
+        if not imdb_id:
+            log('No IMDb ID found - cannot perform Trakt action')
+            return
+
+        # Build the plugin URL
+        plugin_action_map = {
+            'add_watchlist': 'trakt_add_watchlist',
+            'remove_watchlist': 'trakt_remove_watchlist',
+            'mark_watched': 'trakt_mark_watched',
+            'mark_unwatched': 'trakt_mark_unwatched'
+        }
+
+        plugin_action = plugin_action_map.get(action)
+        if not plugin_action:
+            log(f'Unknown action: {action}')
+            return
+
+        # Execute the plugin action
+        plugin_url = f'plugin://plugin.video.aiostreams/?action={plugin_action}&imdb_id={imdb_id}&media_type={media_type}'
+        log(f'Executing: RunPlugin({plugin_url})')
+        xbmc.executebuiltin(f'RunPlugin({plugin_url})')
+
+        # Wait a moment for the action to complete
+        xbmc.sleep(500)
+
+        # Refresh widgets based on action type
+        if action in ['add_watchlist', 'remove_watchlist']:
+            log('Refreshing watchlist widgets')
+            # Refresh watchlist widgets (Home widgets 1 and 2, Movie widgets, TV widgets)
+            # Home Watchlist Movies (10200) and Watchlist Series (10300)
+            xbmc.executebuiltin('Container(10200).Refresh')
+            xbmc.executebuiltin('Container(10300).Refresh')
+            # Also refresh any other watchlist-related widgets
+            for widget_id in range(5100, 5300, 10):  # Movie widgets
+                xbmc.executebuiltin(f'Container({widget_id}).Refresh')
+            for widget_id in range(6100, 6300, 10):  # TV widgets
+                xbmc.executebuiltin(f'Container({widget_id}).Refresh')
+
+        elif action in ['mark_watched', 'mark_unwatched']:
+            log('Refreshing Next Up list')
+            # Refresh Next Up widget (10100)
+            xbmc.executebuiltin('Container(10100).Refresh')
+            # Also refresh any progress/continue watching widgets
+            for widget_id in range(10100, 10400, 100):
+                xbmc.executebuiltin(f'Container({widget_id}).Refresh')
+
+    except Exception as e:
+        log(f'Error performing Trakt action: {e}')
+        import traceback
+        log(traceback.format_exc())
+
+
+if __name__ == '__main__':
+    # Parse arguments
+    if len(sys.argv) > 1:
+        args = sys.argv[1].split(',')
+        action_arg = [arg for arg in args if arg.startswith('action=')]
+        if action_arg:
+            action = action_arg[0].split('=')[1]
+            perform_action(action)

--- a/skin.AIODI/xml/DialogVideoInfo.xml
+++ b/skin.AIODI/xml/DialogVideoInfo.xml
@@ -93,10 +93,10 @@
                             <colordiffuse>FFFFFFFF</colordiffuse>
                             <texturefocus>special://skin/media/buttons/tr_play_fo.png</texturefocus>
                             <texturenofocus>special://skin/media/buttons/tr_play_nofo.png</texturenofocus>
-							<onclick condition="String.IsEqual(ListItem.Property(content_type),series)">ActivateWindow(Videos,plugin://plugin.video.aiostreams/?action=show_seasons&amp;meta_id=$INFO[ListItem.Property(id)],return)</onclick>
+							<onclick condition="String.IsEqual(ListItem.Property(content_type),series) | String.IsEqual(ListItem.DBType,tvshow) | String.IsEqual(ListItem.DBType,series)">ActivateWindow(Videos,plugin://plugin.video.aiostreams/?action=show_seasons&amp;meta_id=$INFO[ListItem.Property(id)],return)</onclick>
 							<onclick condition="String.IsEqual(ListItem.Property(content_type),movie)">ActivateWindow(Videos,plugin://plugin.video.aiostreams/?action=play&amp;content_type=movie&amp;imdb_id=$INFO[ListItem.Property(id)],return)</onclick>
 							<onclick condition="String.StartsWith(ListItem.FileNameAndPath,plugin://plugin.video.youtube)">ActivateWindow(Videos,$INFO[ListItem.FileNameAndPath],return)</onclick>
-							<onclick condition="!String.IsEqual(ListItem.DBType,tvshow) + !String.IsEqual(ListItem.DBType,season) + !String.IsEqual(ListItem.DBType,series)">PlayMedia($INFO[ListItem.FileNameAndPath])</onclick>
+							<onclick condition="!String.IsEqual(ListItem.DBType,tvshow) + !String.IsEqual(ListItem.DBType,season) + !String.IsEqual(ListItem.DBType,series) + !String.IsEqual(ListItem.Property(content_type),series)">RunScript(special://skin/resources/lib/resume_helper.py)</onclick>
 							<visible>!String.IsEmpty(ListItem.Title) | !String.IsEmpty(ListItem.Label)</visible>
 							<onleft>2001</onleft>
                             <onright>50</onright>
@@ -121,12 +121,10 @@
                             <texturefocus condition="!String.IsEqual(Window(Home).Property(InfoWindow.IsWatchlist),true)">special://skin/media/buttons/tr_watchlist_add_fo.png</texturefocus>
                             <texturenofocus condition="String.IsEqual(Window(Home).Property(InfoWindow.IsWatchlist),true)">special://skin/media/buttons/tr_watchlist_remove_nofo.png</texturenofocus>
                             <texturenofocus condition="!String.IsEqual(Window(Home).Property(InfoWindow.IsWatchlist),true)">special://skin/media/buttons/tr_watchlist_add_nofo.png</texturenofocus>
-                            <onclick condition="String.IsEqual(Window(Home).Property(InfoWindow.IsWatchlist),true)">RunPlugin(plugin://plugin.video.aiostreams/?action=trakt_remove_watchlist&amp;imdb_id=$INFO[Window(Home).Property(InfoWindow.IMDB)]&amp;media_type=$INFO[Window(Home).Property(InfoWindow.DBType)])</onclick>
+                            <onclick condition="String.IsEqual(Window(Home).Property(InfoWindow.IsWatchlist),true)">RunScript(special://skin/resources/lib/trakt_action.py,action=remove_watchlist)</onclick>
                             <onclick condition="String.IsEqual(Window(Home).Property(InfoWindow.IsWatchlist),true)">SetProperty(InfoWindow.IsWatchlist,false,home)</onclick>
-                            <onclick condition="String.IsEqual(Window(Home).Property(InfoWindow.IsWatchlist),true)">Container.Refresh</onclick>
-                            <onclick condition="!String.IsEqual(Window(Home).Property(InfoWindow.IsWatchlist),true)">RunPlugin(plugin://plugin.video.aiostreams/?action=trakt_add_watchlist&amp;imdb_id=$INFO[Window(Home).Property(InfoWindow.IMDB)]&amp;media_type=$INFO[Window(Home).Property(InfoWindow.DBType)])</onclick>
+                            <onclick condition="!String.IsEqual(Window(Home).Property(InfoWindow.IsWatchlist),true)">RunScript(special://skin/resources/lib/trakt_action.py,action=add_watchlist)</onclick>
                             <onclick condition="!String.IsEqual(Window(Home).Property(InfoWindow.IsWatchlist),true)">SetProperty(InfoWindow.IsWatchlist,true,home)</onclick>
-                            <onclick condition="!String.IsEqual(Window(Home).Property(InfoWindow.IsWatchlist),true)">Container.Refresh</onclick>
                             <onup>2001</onup>
                             <onright>2003</onright>
                         </control>
@@ -149,12 +147,10 @@
                             <texturefocus condition="!String.IsEqual(Window(Home).Property(InfoWindow.IsWatched),true)">special://skin/media/buttons/tr_watched_add_fo.png</texturefocus>
                             <texturenofocus condition="String.IsEqual(Window(Home).Property(InfoWindow.IsWatched),true)">special://skin/media/buttons/tr_watched_remove_nofo.png</texturenofocus>
                             <texturenofocus condition="!String.IsEqual(Window(Home).Property(InfoWindow.IsWatched),true)">special://skin/media/buttons/tr_watched_add_nofo.png</texturenofocus>
-                            <onclick condition="String.IsEqual(Window(Home).Property(InfoWindow.IsWatched),true)">RunPlugin(plugin://plugin.video.aiostreams/?action=trakt_mark_unwatched&amp;imdb_id=$INFO[Window(Home).Property(InfoWindow.IMDB)]&amp;media_type=$INFO[Window(Home).Property(InfoWindow.DBType)])</onclick>
+                            <onclick condition="String.IsEqual(Window(Home).Property(InfoWindow.IsWatched),true)">RunScript(special://skin/resources/lib/trakt_action.py,action=mark_unwatched)</onclick>
                             <onclick condition="String.IsEqual(Window(Home).Property(InfoWindow.IsWatched),true)">SetProperty(InfoWindow.IsWatched,false,home)</onclick>
-                            <onclick condition="String.IsEqual(Window(Home).Property(InfoWindow.IsWatched),true)">Container.Refresh</onclick>
-                            <onclick condition="!String.IsEqual(Window(Home).Property(InfoWindow.IsWatched),true)">RunPlugin(plugin://plugin.video.aiostreams/?action=trakt_mark_watched&amp;imdb_id=$INFO[Window(Home).Property(InfoWindow.IMDB)]&amp;media_type=$INFO[Window(Home).Property(InfoWindow.DBType)])</onclick>
+                            <onclick condition="!String.IsEqual(Window(Home).Property(InfoWindow.IsWatched),true)">RunScript(special://skin/resources/lib/trakt_action.py,action=mark_watched)</onclick>
                             <onclick condition="!String.IsEqual(Window(Home).Property(InfoWindow.IsWatched),true)">SetProperty(InfoWindow.IsWatched,true,home)</onclick>
-                            <onclick condition="!String.IsEqual(Window(Home).Property(InfoWindow.IsWatched),true)">Container.Refresh</onclick>
                             <onup>8</onup>
                             <onleft>2002</onleft>
                             <onright>50</onright>
@@ -272,100 +268,6 @@
 					<visible>false</visible>
 				</control>
 			</control>
-			<control type="grouplist">
-				<left>0</left>
-				<top>310</top>
-				<width>1147</width>
-				<height>90</height>
-				<itemgap>5</itemgap>
-				<orientation>horizontal</orientation>
-				<usecontrolcoords>true</usecontrolcoords>
-				
-				<control type="group">
-					<width>280</width>
-					<height>90</height>
-					<control type="label">
-						<top>10</top>
-						<width>270</width>
-						<height>25</height>
-						<label>Director</label>
-						<font>font12</font>
-						<textcolor>grey</textcolor>
-					</control>
-					<control type="label">
-						<top>35</top>
-						<width>270</width>
-						<height>30</height>
-						<label>$VAR[InfoDirectorVar]</label>
-						<font>font13</font>
-						<textcolor>white</textcolor>
-						<scroll>true</scroll>
-					</control>
-				</control>
-				
-				<control type="group">
-					<width>280</width>
-					<height>90</height>
-					<control type="label">
-						<top>10</top>
-						<width>270</width>
-						<height>25</height>
-						<label>Released</label>
-						<font>font12</font>
-						<textcolor>grey</textcolor>
-					</control>
-					<control type="label">
-						<top>35</top>
-						<width>270</width>
-						<height>30</height>
-						<label>$VAR[InfoPremieredVar]</label>
-						<font>font13</font>
-						<textcolor>white</textcolor>
-					</control>
-				</control>
-
-				<control type="group">
-					<width>280</width>
-					<height>90</height>
-					<control type="label">
-						<top>10</top>
-						<width>270</width>
-						<height>25</height>
-						<label>Duration</label>
-						<font>font12</font>
-						<textcolor>grey</textcolor>
-					</control>
-					<control type="label">
-						<top>35</top>
-						<width>270</width>
-						<height>30</height>
-						<label>$VAR[InfoDurationVar]</label>
-						<font>font13</font>
-						<textcolor>white</textcolor>
-					</control>
-				</control>
-
-				<control type="group">
-					<width>280</width>
-					<height>90</height>
-					<control type="label">
-						<top>10</top>
-						<width>270</width>
-						<height>25</height>
-						<label>Type</label>
-						<font>font12</font>
-						<textcolor>grey</textcolor>
-					</control>
-					<control type="label">
-						<top>35</top>
-						<width>270</width>
-						<height>30</height>
-						<label>$VAR[InfoDBTypeVar]</label>
-						<font>font13</font>
-						<textcolor>white</textcolor>
-					</control>
-				</control>
-			</control>
 				<control type="image">
 					<left>77</left>
 					<top>185</top>
@@ -381,7 +283,7 @@
 					<top>400</top>
 					<width>1245</width>
 					<height>800</height>
-					
+
 					<!-- Loading Indicator -->
 					<control type="group">
 						<visible>!String.IsEmpty(Window(Home).Property(AsyncLoading))</visible>
@@ -394,12 +296,87 @@
 							<animation effect="rotate" center="auto" start="0" end="360" time="1000" loop="true" condition="true">Conditional</animation>
 						</control>
 					</control>
-					
+
+					<!-- Metadata Column (Right of Cast) -->
+					<control type="grouplist">
+						<left>1000</left>
+						<top>0</top>
+						<width>245</width>
+						<height>280</height>
+						<itemgap>15</itemgap>
+						<orientation>vertical</orientation>
+						<usecontrolcoords>true</usecontrolcoords>
+
+						<control type="group">
+							<width>245</width>
+							<height>50</height>
+							<control type="label">
+								<top>0</top>
+								<width>245</width>
+								<height>20</height>
+								<label>Director</label>
+								<font>font10</font>
+								<textcolor>grey</textcolor>
+							</control>
+							<control type="label">
+								<top>20</top>
+								<width>245</width>
+								<height>25</height>
+								<label>$VAR[InfoDirectorVar]</label>
+								<font>font12</font>
+								<textcolor>white</textcolor>
+								<scroll>true</scroll>
+							</control>
+						</control>
+
+						<control type="group">
+							<width>245</width>
+							<height>50</height>
+							<control type="label">
+								<top>0</top>
+								<width>245</width>
+								<height>20</height>
+								<label>Released</label>
+								<font>font10</font>
+								<textcolor>grey</textcolor>
+							</control>
+							<control type="label">
+								<top>20</top>
+								<width>245</width>
+								<height>25</height>
+								<label>$VAR[InfoPremieredVar]</label>
+								<font>font12</font>
+								<textcolor>white</textcolor>
+							</control>
+						</control>
+
+						<control type="group">
+							<width>245</width>
+							<height>50</height>
+							<control type="label">
+								<top>0</top>
+								<width>245</width>
+								<height>20</height>
+								<label>Duration</label>
+								<font>font10</font>
+								<textcolor>grey</textcolor>
+							</control>
+							<control type="label">
+								<top>20</top>
+								<width>245</width>
+								<height>25</height>
+								<label>$VAR[InfoDurationVar]</label>
+								<font>font12</font>
+								<textcolor>white</textcolor>
+							</control>
+						</control>
+					</control>
+
 					<!-- Cast List (Refactored) -->
 					<control type="fixedlist" id="50">
 						<left>0</left>
 						<top>0</top>
-						<width>1245</width>
+						<width>980</width>
 						<height>280</height>
 						<onup>8000</onup>
 						<onleft>8</onleft>

--- a/skin.AIODI/xml/Home.xml
+++ b/skin.AIODI/xml/Home.xml
@@ -151,7 +151,7 @@
 		<top>0</top>
 		<width>120</width>
 		<bottom>0</bottom>
-		<texture colordiffuse="FF000000">colors/white.png</texture>
+		<texture colordiffuse="4D000000">colors/white.png</texture>
 	</control>
 
 	<!-- Top Group (Logo & Search) -->
@@ -179,7 +179,7 @@
 				<top>7</top>
 				<width>71</width>
 				<height>71</height>
-				<texture>logonew.png</texture>
+				<texture>logo_unfocused.png</texture>
 				<colordiffuse>FFFFFFFF</colordiffuse>
 				<visible>!Control.HasFocus(9001)</visible>
 			</control>
@@ -188,8 +188,8 @@
 				<top>7</top>
 				<width>71</width>
 				<height>71</height>
-				<texture>https://raw.githubusercontent.com/shiggsy365/AIOStreamsKODI/main/docs/plugin.video.aiostreams/resources/icon(1).png</texture>
-				<colordiffuse>FFFFFFFF</colordiffuse>
+				<texture>logo_unfocused.png</texture>
+				<colordiffuse>FFFF0000</colordiffuse>
 				<visible>Control.HasFocus(9001)</visible>
 			</control>
 		</control>
@@ -483,7 +483,7 @@
 <!-- Home Widgets -->
 <control type="group" id="11000">
 	<zorder>10</zorder>
-	<bottom>20</bottom>
+	<bottom>50</bottom>
 	<left>150</left>
 	<width>1750</width>
 	<height>550</height>
@@ -659,7 +659,7 @@
 <!-- Movie Widgets -->
 	<control type="group" id="5000">
 	<zorder>10</zorder>
-	<bottom>20</bottom>
+	<bottom>50</bottom>
 	<left>150</left>
 	<width>1750</width>
 	<height>550</height>
@@ -1104,7 +1104,7 @@
 <!-- ========== TV SHOWS WIDGETS (20 ROWS) ========== -->
 <control type="group" id="6000">
 	<zorder>10</zorder>
-	<bottom>20</bottom>
+	<bottom>50</bottom>
 	<left>150</left>
 	<width>1750</width>
 	<height>550</height>
@@ -1490,7 +1490,7 @@
 	<!-- Music Widgets -->
 	<control type="group" id="7000">
 		<zorder>10</zorder>
-		<bottom>20</bottom>
+		<bottom>50</bottom>
 		<left>150</left>
 		<width>1750</width>
 		<height>550</height>

--- a/skin.AIODI/xml/Includes_Home.xml
+++ b/skin.AIODI/xml/Includes_Home.xml
@@ -402,7 +402,7 @@
 					<ondown>$PARAM[ondown_action1]</ondown>
 					<ondown>$PARAM[ondown_action2]</ondown>
 					<onclick condition="[String.IsEqual(ListItem.DBType,tvshow) | String.IsEqual(ListItem.DBType,season)]">ActivateWindow(Videos,$INFO[ListItem.FolderPath],return)</onclick>
-					<onclick condition="![String.IsEqual(ListItem.DBType,tvshow) | String.IsEqual(ListItem.DBType,season)] + [String.IsEmpty($PARAM[onclick_action]) | String.IsEqual($PARAM[onclick_action],noop)]">PlayMedia($INFO[ListItem.FileNameAndPath])</onclick>
+					<onclick condition="![String.IsEqual(ListItem.DBType,tvshow) | String.IsEqual(ListItem.DBType,season)] + [String.IsEmpty($PARAM[onclick_action]) | String.IsEqual($PARAM[onclick_action],noop)]">RunScript(special://skin/resources/lib/resume_helper.py)</onclick>
 					<onclick condition="!String.IsEqual($PARAM[onclick_action],noop) + !String.IsEmpty($PARAM[onclick_action])">$PARAM[onclick_action]</onclick>
 					<onfocus>Skin.SetString(ActiveWidgetID,$PARAM[list_id])</onfocus>
 					
@@ -543,7 +543,7 @@
 							</control>
 						</control>
 					</itemlayout>
-					<focusedlayout width="240" height="360" condition="!String.IsEqual(ListItem.DBType,episode)">
+					<focusedlayout width="240" height="360" condition="!String.IsEqual(ListItem.DBType,episode) + !Control.HasFocus(10100)">
 						<control type="group">
 							<animation effect="zoom" center="auto" start="100" end="110" time="200" tween="sine" easing="out">Focus</animation>
 							<control type="image">
@@ -591,6 +591,57 @@
 							</control>
 						</control>
 					</focusedlayout>
+
+					<!-- LANDSCAPE FOCUSED LAYOUT (for Next Up widget when focused) -->
+					<focusedlayout width="410" height="360" condition="!String.IsEqual(ListItem.DBType,episode) + Control.HasFocus(10100)">
+						<control type="group">
+							<top>65</top>
+							<animation effect="zoom" center="auto" start="100" end="110" time="200" tween="sine" easing="out">Focus</animation>
+							<control type="image">
+								<width>390</width>
+								<height>220</height>
+								<aspectratio align="center" aligny="center">scale</aspectratio>
+								<texture background="true">$INFO[ListItem.Art(thumb)]</texture>
+								<fallback>$INFO[ListItem.Art(poster)]</fallback>
+								<bordertexture border="3" colordiffuse="FFFF0000">colors/white.png</bordertexture>
+								<bordersize>3</bordersize>
+								<borderradius>8</borderradius>
+							</control>
+							<!-- Watched Indicator -->
+							<control type="image">
+								<right>30</right>
+								<top>5</top>
+								<width>30</width>
+								<height>30</height>
+								<texture>indicator_watched.png</texture>
+								<visible>String.IsEqual(ListItem.Property(watched),true) | String.IsEqual(ListItem.Overlay,OverlayWatched.png) | Integer.IsGreater(ListItem.Playcount,0) | Integer.IsGreater(ListItem.PercentPlayed,95)</visible>
+							</control>
+							<!-- Percentage Indicator -->
+							<control type="group">
+								<right>25</right>
+								<top>5</top>
+								<width>40</width>
+								<height>40</height>
+								<visible>[Integer.IsGreater(ListItem.PercentPlayed,4) | Integer.IsGreater(ListItem.Property(PercentPlayed),4)] + [Integer.IsLess(ListItem.PercentPlayed,96) | Integer.IsLess(ListItem.Property(PercentPlayed),96)]</visible>
+								<control type="image">
+									<width>40</width>
+									<height>40</height>
+									<texture>PercentageCircle.png</texture>
+								</control>
+								<control type="label">
+									<width>40</width>
+									<height>40</height>
+									<align>center</align>
+									<aligny>center</aligny>
+									<font>font_tiny</font>
+									<label>$VAR[PercentPlayedVar]%</label>
+									<textcolor>red</textcolor>
+									<shadowcolor>FF000000</shadowcolor>
+								</control>
+							</control>
+						</control>
+					</focusedlayout>
+
 					<content limit="20" target="$PARAM[widget_target]" browse="$PARAM[browse_mode]">$PARAM[content_path]&amp;reload=$INFO[Skin.String(WidgetReloadToken)]</content>
 				</control>
 				<!-- LOADING INDICATOR -->

--- a/skin.AIODI/xml/Variables.xml
+++ b/skin.AIODI/xml/Variables.xml
@@ -1225,6 +1225,10 @@
 <value>overlays/checkbox-off.png</value>
 </variable>
 	<variable name="CurrentWidgetTitle">
+		<!-- Menu buttons focused - show first item of first widget -->
+		<value condition="Control.HasFocus(9003) + !String.IsEmpty(Container(10100).ListItem(0).Title)">$INFO[Container(10100).ListItem(0).Title]</value>
+		<value condition="Control.HasFocus(9005) + !String.IsEmpty(Container(5100).ListItem(0).Title)">$INFO[Container(5100).ListItem(0).Title]</value>
+		<value condition="Control.HasFocus(9004) + !String.IsEmpty(Container(6100).ListItem(0).Title)">$INFO[Container(6100).ListItem(0).Title]</value>
 		<value condition="Control.HasFocus(7100)">$INFO[Container(7100).ListItem.Label]</value>
 		<value condition="Control.HasFocus(10100) + !String.IsEmpty(Container(10100).ListItem.Title)">$INFO[Container(10100).ListItem.Title]</value>
 		<value condition="Control.HasFocus(20100) + !String.IsEmpty(Container(20100).ListItem.Title)">$INFO[Container(20100).ListItem.Title]</value>
@@ -1235,6 +1239,10 @@
 	</variable>
 
 	<variable name="CurrentWidgetFanart">
+		<!-- Menu buttons focused - show first item of first widget -->
+		<value condition="Control.HasFocus(9003)">$INFO[Container(10100).ListItem(0).Art(fanart)]</value>
+		<value condition="Control.HasFocus(9005)">$INFO[Container(5100).ListItem(0).Art(fanart)]</value>
+		<value condition="Control.HasFocus(9004)">$INFO[Container(6100).ListItem(0).Art(fanart)]</value>
 		<value condition="Control.HasFocus(7100)">$INFO[Container(7100).ListItem.Art(fanart)]</value>
 		<value condition="Control.HasFocus(7200)">$INFO[Container(7200).ListItem.Art(fanart)]</value>
 		<value condition="Control.HasFocus(10100)">$INFO[Container(10100).ListItem.Art(fanart)]</value>
@@ -1246,6 +1254,12 @@
 	</variable>
 
 	<variable name="CurrentWidgetClearLogo">
+		<!-- Menu buttons focused - show first item of first widget -->
+		<value condition="Control.HasFocus(9003) + !String.IsEmpty(Container(10100).ListItem(0).Art(clearlogo))">$INFO[Container(10100).ListItem(0).Art(clearlogo)]</value>
+		<value condition="Control.HasFocus(9003) + !String.IsEmpty(Container(10100).ListItem(0).Art(tvshow.clearlogo))">$INFO[Container(10100).ListItem(0).Art(tvshow.clearlogo)]</value>
+		<value condition="Control.HasFocus(9005) + !String.IsEmpty(Container(5100).ListItem(0).Art(clearlogo))">$INFO[Container(5100).ListItem(0).Art(clearlogo)]</value>
+		<value condition="Control.HasFocus(9004) + !String.IsEmpty(Container(6100).ListItem(0).Art(clearlogo))">$INFO[Container(6100).ListItem(0).Art(clearlogo)]</value>
+		<value condition="Control.HasFocus(9004) + !String.IsEmpty(Container(6100).ListItem(0).Art(tvshow.clearlogo))">$INFO[Container(6100).ListItem(0).Art(tvshow.clearlogo)]</value>
 		<value condition="Control.HasFocus(7100) + !String.IsEmpty(Container(7100).ListItem.Art(clearlogo))">$INFO[Container(7100).ListItem.Art(clearlogo)]</value>
 		<value condition="Control.HasFocus(7100) + !String.IsEmpty(Container(7100).ListItem.Art(tvshow.clearlogo))">$INFO[Container(7100).ListItem.Art(tvshow.clearlogo)]</value>
 		<value condition="Control.HasFocus(7200) + !String.IsEmpty(Container(7200).ListItem.Art(clearlogo))">$INFO[Container(7200).ListItem.Art(clearlogo)]</value>
@@ -1264,6 +1278,10 @@
 	</variable>
 
 	<variable name="CurrentWidgetPlot">
+		<!-- Menu buttons focused - show first item of first widget -->
+		<value condition="Control.HasFocus(9003)">$INFO[Container(10100).ListItem(0).Plot]</value>
+		<value condition="Control.HasFocus(9005)">$INFO[Container(5100).ListItem(0).Plot]</value>
+		<value condition="Control.HasFocus(9004)">$INFO[Container(6100).ListItem(0).Plot]</value>
 		<value condition="Control.HasFocus(7100)">$INFO[Container(7100).ListItem.Plot]</value>
 		<value condition="Control.HasFocus(7200)">$INFO[Container(7200).ListItem.Plot]</value>
 		<value condition="Control.HasFocus(10100)">$INFO[Container(10100).ListItem.Plot]</value>
@@ -1275,9 +1293,15 @@
 	</variable>
 
 	<variable name="CurrentWidgetInfo">
+		<!-- Menu buttons focused - show first item of first widget -->
+		<value condition="Control.HasFocus(9003) + !String.IsEmpty(Container(10100).ListItem(0).Property(AiredDate))">$INFO[Container(10100).ListItem(0).Property(AiredDate)]$INFO[Container(10100).ListItem(0).Duration,  |  , min]</value>
+		<value condition="Control.HasFocus(9003) + !String.IsEmpty(Container(10100).ListItem(0).Season)">S$INFO[Container(10100).ListItem(0).Season]E$INFO[Container(10100).ListItem(0).Episode]$INFO[Container(10100).ListItem(0).Duration,  |  , min]</value>
+		<value condition="Control.HasFocus(9003)">$INFO[Container(10100).ListItem(0).Year]$INFO[Container(10100).ListItem(0).Genre,  |  ]$INFO[Container(10100).ListItem(0).Duration,  |  , min]</value>
+		<value condition="Control.HasFocus(9005)">$INFO[Container(5100).ListItem(0).Year]$INFO[Container(5100).ListItem(0).Genre,  |  ]$INFO[Container(5100).ListItem(0).Duration,  |  , min]</value>
+		<value condition="Control.HasFocus(9004)">$INFO[Container(6100).ListItem(0).Year]$INFO[Container(6100).ListItem(0).Genre,  |  ]</value>
 		<!-- Focused Widget Manager item -->
 		<value condition="Control.HasFocus(7100)">$INFO[Container(7100).ListItem.Premiered]$INFO[Container(7100).ListItem.Genre,  |  ]</value>
-		
+
 		<!-- Trakt Next Up (10100) -->
 		<value condition="String.IsEqual($VAR[ActiveWidgetID],10100) + !String.IsEmpty(Container(10100).ListItem.Property(AiredDate))">
 			$INFO[Container(10100).ListItem.Property(AiredDate)]$INFO[Container(10100).ListItem.Duration,  |  , min]$INFO[Container(10100).ListItem.Director,  |  ]


### PR DESCRIPTION
This commit implements multiple enhancements to the AIODI skin:

Widget Positioning & Layout:
- Move all widgets to 50px from bottom of screen (previously 20px)
- Add landscape orientation for Next Up widget when focused
- Episodes always display in landscape orientation

Metadata Display:
- Main menu items now display metadata from first widget item when focused
- Updated variables for Home, Movies, and TV Shows sections
- Metadata includes title, clearlogo, fanart, plot, and info

Information Panel Improvements:
- Relocate director, release date, and duration to right of cast area
- Stack metadata vertically with smaller text (font10/font12)
- Reduce cast list width to 980px to accommodate metadata column

Dialog Functionality:
- Fix TV show season browse from search results
- Add Trakt action helper script for watchlist and watched operations
- Watchlist/Watched buttons now properly toggle state
- Widget refresh after Trakt operations (watchlist and watched status)

Playback Features:
- Add resume helper for partially watched items
- Show dialog to resume or start from beginning for items 5-95% watched
- Integrate resume functionality in widgets and info dialog

UI/UX Enhancements:
- Make main menu bar 70% transparent (30% opacity)
- Update AIODI logo to use logo_unfocused.png
- Logo displays in red when focused

Files modified:
- Home.xml: Widget positions, sidebar transparency, logo updates
- Includes_Home.xml: Widget layouts, resume helper integration
- Variables.xml: Metadata variables for menu focus states
- DialogVideoInfo.xml: Metadata layout, button functionality, resume helper
- trakt_action.py: New helper for Trakt operations with widget refresh
- resume_helper.py: New helper for resume playback dialog