### PR TITLE
AIODI Skin: Chip styling, button fixes, and genre display improvements

### DIFF
--- a/skin.AIODI/resources/lib/genre_splitter.py
+++ b/skin.AIODI/resources/lib/genre_splitter.py
@@ -10,13 +10,9 @@ import sys
 def split_genres():
     """Split genre string from focused widget item into individual genres (max 3)."""
     try:
-        # Get the active widget ID
-        active_widget = xbmc.getInfoLabel('Skin.String(ActiveWidgetID)')
-        if not active_widget:
-            return
-
-        # Get genre string from the current list item
-        genre_string = xbmc.getInfoLabel(f'Container({active_widget}).ListItem.Genre')
+        # Get genre string from the currently focused list item
+        # When called from onfocus, ListItem refers to the focused item
+        genre_string = xbmc.getInfoLabel('ListItem.Genre')
 
         win = xbmcgui.Window(10000)
 

--- a/skin.AIODI/resources/lib/trakt_action.py
+++ b/skin.AIODI/resources/lib/trakt_action.py
@@ -54,8 +54,17 @@ def perform_action(action):
             log(f'Unknown action: {action}')
             return
 
-        # Execute the plugin action
+        # Build the plugin URL
         plugin_url = f'plugin://plugin.video.aiostreams/?action={plugin_action}&imdb_id={imdb_id}&media_type={media_type}'
+
+        # For episodes, add season and episode parameters for mark watched/unwatched actions
+        if db_type == 'episode' and action in ['mark_watched', 'mark_unwatched']:
+            season = xbmc.getInfoLabel('ListItem.Season')
+            episode = xbmc.getInfoLabel('ListItem.Episode')
+            if season and episode:
+                plugin_url += f'&season={season}&episode={episode}'
+                log(f'Episode action: Season {season}, Episode {episode}')
+
         log(f'Executing: RunPlugin({plugin_url})')
         xbmc.executebuiltin(f'RunPlugin({plugin_url})')
 

--- a/skin.AIODI/xml/DialogVideoInfo.xml
+++ b/skin.AIODI/xml/DialogVideoInfo.xml
@@ -93,6 +93,8 @@
                             <colordiffuse>FFFFFFFF</colordiffuse>
                             <texturefocus>special://skin/media/buttons/tr_play_fo.png</texturefocus>
                             <texturenofocus>special://skin/media/buttons/tr_play_nofo.png</texturenofocus>
+							<onclick condition="String.IsEqual(ListItem.Property(content_type),series) | String.IsEqual(ListItem.DBType,tvshow) | String.IsEqual(ListItem.DBType,series)">Dialog.Close(1107)</onclick>
+							<onclick condition="String.IsEqual(ListItem.Property(content_type),series) | String.IsEqual(ListItem.DBType,tvshow) | String.IsEqual(ListItem.DBType,series)">Dialog.Close(1108)</onclick>
 							<onclick condition="String.IsEqual(ListItem.Property(content_type),series) | String.IsEqual(ListItem.DBType,tvshow) | String.IsEqual(ListItem.DBType,series)">Dialog.Close(movieinformation)</onclick>
 							<onclick condition="String.IsEqual(ListItem.Property(content_type),series) | String.IsEqual(ListItem.DBType,tvshow) | String.IsEqual(ListItem.DBType,series)">ActivateWindow(Videos,plugin://plugin.video.aiostreams/?action=show_seasons&amp;meta_id=$INFO[ListItem.Property(id)],return)</onclick>
 							<onclick condition="String.IsEqual(ListItem.Property(content_type),movie)">ActivateWindow(Videos,plugin://plugin.video.aiostreams/?action=play&amp;content_type=movie&amp;imdb_id=$INFO[ListItem.Property(id)],return)</onclick>
@@ -110,25 +112,6 @@
                             <top>74</top>
                             <width>258</width>
                             <height>64</height>
-                            <control type="button" id="2002">
-                                <width>258</width>
-                                <height>64</height>
-                                <label>Watchlist</label>
-                                <font>font24_bold</font>
-                                <textoffsetx>60</textoffsetx>
-                                <align>left</align>
-                                <aligny>center</aligny>
-                                <textcolor>FFFFFFFF</textcolor>
-                                <focusedcolor>FFFFFFFF</focusedcolor>
-                                <texturefocus>-</texturefocus>
-                                <texturenofocus>-</texturenofocus>
-                                <onclick condition="String.IsEqual(Window(Home).Property(InfoWindow.IsWatchlist),true)">RunScript(special://skin/resources/lib/trakt_action.py,action=remove_watchlist)</onclick>
-                                <onclick condition="String.IsEqual(Window(Home).Property(InfoWindow.IsWatchlist),true)">SetProperty(InfoWindow.IsWatchlist,false,home)</onclick>
-                                <onclick condition="!String.IsEqual(Window(Home).Property(InfoWindow.IsWatchlist),true)">RunScript(special://skin/resources/lib/trakt_action.py,action=add_watchlist)</onclick>
-                                <onclick condition="!String.IsEqual(Window(Home).Property(InfoWindow.IsWatchlist),true)">SetProperty(InfoWindow.IsWatchlist,true,home)</onclick>
-                                <onup>2001</onup>
-                                <onright>2003</onright>
-                            </control>
                             <!-- Dynamic background images -->
                             <control type="image">
                                 <width>258</width>
@@ -154,18 +137,10 @@
                                 <texture>special://skin/media/buttons/tr_watchlist_add_nofo.png</texture>
                                 <visible>!Control.HasFocus(2002) + !String.IsEqual(Window(Home).Property(InfoWindow.IsWatchlist),true)</visible>
                             </control>
-                        </control>
-
-                        <!-- Row 2 Right: Watched -->
-                        <control type="group">
-                            <left>268</left>
-                            <top>74</top>
-                            <width>258</width>
-                            <height>64</height>
-                            <control type="button" id="2003">
+                            <control type="button" id="2002">
                                 <width>258</width>
                                 <height>64</height>
-                                <label>Watched</label>
+                                <label>Watchlist</label>
                                 <font>font24_bold</font>
                                 <textoffsetx>60</textoffsetx>
                                 <align>left</align>
@@ -174,14 +149,21 @@
                                 <focusedcolor>FFFFFFFF</focusedcolor>
                                 <texturefocus>-</texturefocus>
                                 <texturenofocus>-</texturenofocus>
-                                <onclick condition="String.IsEqual(Window(Home).Property(InfoWindow.IsWatched),true)">RunScript(special://skin/resources/lib/trakt_action.py,action=mark_unwatched)</onclick>
-                                <onclick condition="String.IsEqual(Window(Home).Property(InfoWindow.IsWatched),true)">SetProperty(InfoWindow.IsWatched,false,home)</onclick>
-                                <onclick condition="!String.IsEqual(Window(Home).Property(InfoWindow.IsWatched),true)">RunScript(special://skin/resources/lib/trakt_action.py,action=mark_watched)</onclick>
-                                <onclick condition="!String.IsEqual(Window(Home).Property(InfoWindow.IsWatched),true)">SetProperty(InfoWindow.IsWatched,true,home)</onclick>
-                                <onup>8</onup>
-                                <onleft>2002</onleft>
-                                <onright>50</onright>
+                                <onclick condition="String.IsEqual(Window(Home).Property(InfoWindow.IsWatchlist),true)">RunScript(special://skin/resources/lib/trakt_action.py,action=remove_watchlist)</onclick>
+                                <onclick condition="String.IsEqual(Window(Home).Property(InfoWindow.IsWatchlist),true)">SetProperty(InfoWindow.IsWatchlist,false,home)</onclick>
+                                <onclick condition="!String.IsEqual(Window(Home).Property(InfoWindow.IsWatchlist),true)">RunScript(special://skin/resources/lib/trakt_action.py,action=add_watchlist)</onclick>
+                                <onclick condition="!String.IsEqual(Window(Home).Property(InfoWindow.IsWatchlist),true)">SetProperty(InfoWindow.IsWatchlist,true,home)</onclick>
+                                <onup>2001</onup>
+                                <onright>2003</onright>
                             </control>
+                        </control>
+
+                        <!-- Row 2 Right: Watched -->
+                        <control type="group">
+                            <left>268</left>
+                            <top>74</top>
+                            <width>258</width>
+                            <height>64</height>
                             <!-- Dynamic background images -->
                             <control type="image">
                                 <width>258</width>
@@ -206,6 +188,26 @@
                                 <height>64</height>
                                 <texture>special://skin/media/buttons/tr_watched_add_nofo.png</texture>
                                 <visible>!Control.HasFocus(2003) + !String.IsEqual(Window(Home).Property(InfoWindow.IsWatched),true)</visible>
+                            </control>
+                            <control type="button" id="2003">
+                                <width>258</width>
+                                <height>64</height>
+                                <label>Watched</label>
+                                <font>font24_bold</font>
+                                <textoffsetx>60</textoffsetx>
+                                <align>left</align>
+                                <aligny>center</aligny>
+                                <textcolor>FFFFFFFF</textcolor>
+                                <focusedcolor>FFFFFFFF</focusedcolor>
+                                <texturefocus>-</texturefocus>
+                                <texturenofocus>-</texturenofocus>
+                                <onclick condition="String.IsEqual(Window(Home).Property(InfoWindow.IsWatched),true)">RunScript(special://skin/resources/lib/trakt_action.py,action=mark_unwatched)</onclick>
+                                <onclick condition="String.IsEqual(Window(Home).Property(InfoWindow.IsWatched),true)">SetProperty(InfoWindow.IsWatched,false,home)</onclick>
+                                <onclick condition="!String.IsEqual(Window(Home).Property(InfoWindow.IsWatched),true)">RunScript(special://skin/resources/lib/trakt_action.py,action=mark_watched)</onclick>
+                                <onclick condition="!String.IsEqual(Window(Home).Property(InfoWindow.IsWatched),true)">SetProperty(InfoWindow.IsWatched,true,home)</onclick>
+                                <onup>8</onup>
+                                <onleft>2002</onleft>
+                                <onright>50</onright>
                             </control>
                         </control>
 					</control>

--- a/skin.AIODI/xml/Home.xml
+++ b/skin.AIODI/xml/Home.xml
@@ -88,6 +88,12 @@
 				<label>$VAR[CurrentWidgetClearLogo]</label>
 			</control>
 
+			<!-- HIDDEN VALUE HOLDER for Season -->
+			<control type="label" id="8889">
+				<include>HiddenObject</include>
+				<label>$INFO[Container($VAR[ActiveWidgetID]).ListItem.Season]</label>
+			</control>
+
 			<!-- ClearLogo -->
 			<control type="image">
 				<left>0</left>
@@ -112,262 +118,369 @@
 				<visible>String.IsEmpty(Control.GetLabel(8888))</visible>
 			</control>
 
-			<!-- Genre Chips (Vertical stack to right of clearlogo, max 3) -->
-			<control type="grouplist">
+			<!-- Genre Chips (to the right of clearlogo, vertically centered) -->
+			<!-- Genre 1 -->
+			<control type="group">
 				<left>520</left>
-				<top>0</top>
-				<width>300</width>
-				<height>180</height>
-				<orientation>vertical</orientation>
-				<itemgap>8</itemgap>
-				<usecontrolcoords>true</usecontrolcoords>
+				<top>30</top>
+				<width>180</width>
+				<height>40</height>
+				<visible>!String.IsEmpty(Window(Home).Property(Widget.Genre.1))</visible>
+				<control type="image">
+					<width>180</width>
+					<height>40</height>
+					<texture colordiffuse="80000000">colors/white.png</texture>
+					<bordersize>2</bordersize>
+					<bordertexture colordiffuse="FFFFFFFF">colors/white.png</bordertexture>
+					<borderradius>4</borderradius>
+				</control>
+				<control type="label">
+					<width>180</width>
+					<height>40</height>
+					<align>center</align>
+					<aligny>center</aligny>
+					<font>font10</font>
+					<textcolor>FFFFFFFF</textcolor>
+					<label>$INFO[Window(Home).Property(Widget.Genre.1)]</label>
+				</control>
+			</control>
 
-				<!-- Genre 1 -->
+			<!-- Genre 2 -->
+			<control type="group">
+				<left>520</left>
+				<top>75</top>
+				<width>180</width>
+				<height>40</height>
+				<visible>!String.IsEmpty(Window(Home).Property(Widget.Genre.2))</visible>
+				<control type="image">
+					<width>180</width>
+					<height>40</height>
+					<texture colordiffuse="80000000">colors/white.png</texture>
+					<bordersize>2</bordersize>
+					<bordertexture colordiffuse="FFFFFFFF">colors/white.png</bordertexture>
+					<borderradius>4</borderradius>
+				</control>
+				<control type="label">
+					<width>180</width>
+					<height>40</height>
+					<align>center</align>
+					<aligny>center</aligny>
+					<font>font10</font>
+					<textcolor>FFFFFFFF</textcolor>
+					<label>$INFO[Window(Home).Property(Widget.Genre.2)]</label>
+				</control>
+			</control>
+
+			<!-- Genre 3 -->
+			<control type="group">
+				<left>520</left>
+				<top>120</top>
+				<width>180</width>
+				<height>40</height>
+				<visible>!String.IsEmpty(Window(Home).Property(Widget.Genre.3))</visible>
+				<control type="image">
+					<width>180</width>
+					<height>40</height>
+					<texture colordiffuse="80000000">colors/white.png</texture>
+					<bordersize>2</bordersize>
+					<bordertexture colordiffuse="FFFFFFFF">colors/white.png</bordertexture>
+					<borderradius>4</borderradius>
+				</control>
+				<control type="label">
+					<width>180</width>
+					<height>40</height>
+					<align>center</align>
+					<aligny>center</aligny>
+					<font>font10</font>
+					<textcolor>FFFFFFFF</textcolor>
+					<label>$INFO[Window(Home).Property(Widget.Genre.3)]</label>
+				</control>
+			</control>
+
+			<!-- Plot Description (aligned with clearlogo) -->
+			<control type="textbox">
+				<left>0</left>
+				<top>200</top>
+				<width>1500</width>
+				<height>220</height>
+				<font>font15</font>
+				<textcolor>FFFFFFFF</textcolor>
+				<label>$VAR[CurrentWidgetPlot]</label>
+				<shadowcolor>text_shadow</shadowcolor>
+				<autoscroll time="3000" delay="4000" repeat="5000">true</autoscroll>
+			</control>
+
+			<!-- Metadata Chips for Episodes: [S01E01] [premiered] [duration] [mpaa] [rating] -->
+			<control type="group">
+				<left>0</left>
+				<top>450</top>
+				<width>1550</width>
+				<height>50</height>
+				<visible>!String.IsEmpty(Control.GetLabel(8889))</visible>
+
+				<!-- Episode Number -->
 				<control type="group">
-					<width>200</width>
-					<height>35</height>
-					<visible>!String.IsEmpty(Window(Home).Property(Widget.Genre.1))</visible>
+					<left>0</left>
+					<top>0</top>
+					<width>120</width>
+					<height>40</height>
 					<control type="image">
-						<width>200</width>
-						<height>35</height>
+						<width>120</width>
+						<height>40</height>
 						<texture colordiffuse="80000000">colors/white.png</texture>
 						<bordersize>2</bordersize>
 						<bordertexture colordiffuse="FFFFFFFF">colors/white.png</bordertexture>
 						<borderradius>4</borderradius>
 					</control>
 					<control type="label">
-						<width>200</width>
-						<height>35</height>
+						<width>120</width>
+						<height>40</height>
 						<align>center</align>
 						<aligny>center</aligny>
-						<font>font13</font>
+						<font>font10</font>
 						<textcolor>FFFFFFFF</textcolor>
-						<label>$INFO[Window(Home).Property(Widget.Genre.1)]</label>
+						<label>$INFO[Container($VAR[ActiveWidgetID]).ListItem.Season,S,]$INFO[Container($VAR[ActiveWidgetID]).ListItem.Episode,E,]</label>
 					</control>
 				</control>
 
-				<!-- Genre 2 -->
+				<!-- Premiered -->
 				<control type="group">
-					<width>200</width>
-					<height>35</height>
-					<visible>!String.IsEmpty(Window(Home).Property(Widget.Genre.2))</visible>
+					<left>130</left>
+					<top>0</top>
+					<width>140</width>
+					<height>40</height>
 					<control type="image">
-						<width>200</width>
-						<height>35</height>
+						<width>140</width>
+						<height>40</height>
 						<texture colordiffuse="80000000">colors/white.png</texture>
 						<bordersize>2</bordersize>
 						<bordertexture colordiffuse="FFFFFFFF">colors/white.png</bordertexture>
 						<borderradius>4</borderradius>
 					</control>
 					<control type="label">
-						<width>200</width>
-						<height>35</height>
+						<width>140</width>
+						<height>40</height>
 						<align>center</align>
 						<aligny>center</aligny>
-						<font>font13</font>
+						<font>font10</font>
 						<textcolor>FFFFFFFF</textcolor>
-						<label>$INFO[Window(Home).Property(Widget.Genre.2)]</label>
+						<label>$INFO[Container($VAR[ActiveWidgetID]).ListItem.Premiered]</label>
 					</control>
 				</control>
 
-				<!-- Genre 3 -->
+				<!-- Duration -->
 				<control type="group">
-					<width>200</width>
-					<height>35</height>
-					<visible>!String.IsEmpty(Window(Home).Property(Widget.Genre.3))</visible>
+					<left>280</left>
+					<top>0</top>
+					<width>120</width>
+					<height>40</height>
 					<control type="image">
-						<width>200</width>
-						<height>35</height>
+						<width>120</width>
+						<height>40</height>
 						<texture colordiffuse="80000000">colors/white.png</texture>
 						<bordersize>2</bordersize>
 						<bordertexture colordiffuse="FFFFFFFF">colors/white.png</bordertexture>
 						<borderradius>4</borderradius>
 					</control>
 					<control type="label">
-						<width>200</width>
-						<height>35</height>
+						<width>120</width>
+						<height>40</height>
 						<align>center</align>
 						<aligny>center</aligny>
-						<font>font13</font>
+						<font>font10</font>
 						<textcolor>FFFFFFFF</textcolor>
-						<label>$INFO[Window(Home).Property(Widget.Genre.3)]</label>
+						<label>$INFO[Container($VAR[ActiveWidgetID]).ListItem.Duration, min]</label>
+					</control>
+				</control>
+
+				<!-- MPAA/Certification -->
+				<control type="group">
+					<left>410</left>
+					<top>0</top>
+					<width>100</width>
+					<height>40</height>
+					<control type="image">
+						<width>100</width>
+						<height>40</height>
+						<texture colordiffuse="80000000">colors/white.png</texture>
+						<bordersize>2</bordersize>
+						<bordertexture colordiffuse="FFDC143C">colors/white.png</bordertexture>
+						<borderradius>4</borderradius>
+					</control>
+					<control type="label">
+						<width>100</width>
+						<height>40</height>
+						<align>center</align>
+						<aligny>center</aligny>
+						<font>font10</font>
+						<textcolor>FFFFFFFF</textcolor>
+						<label>$INFO[Container($VAR[ActiveWidgetID]).ListItem.Mpaa]</label>
+					</control>
+				</control>
+
+				<!-- IMDb Rating with Logo -->
+				<control type="group">
+					<left>520</left>
+					<top>0</top>
+					<width>150</width>
+					<height>40</height>
+
+					<!-- IMDb Logo -->
+					<control type="image">
+						<left>0</left>
+						<top>0</top>
+						<width>60</width>
+						<height>40</height>
+						<texture>imdb_logo.png</texture>
+						<aspectratio>keep</aspectratio>
+					</control>
+
+					<!-- Rating Chip -->
+					<control type="image">
+						<left>70</left>
+						<top>0</top>
+						<width>80</width>
+						<height>40</height>
+						<texture colordiffuse="80000000">colors/white.png</texture>
+						<bordersize>2</bordersize>
+						<bordertexture colordiffuse="FFF5C518">colors/white.png</bordertexture>
+						<borderradius>4</borderradius>
+					</control>
+					<control type="label">
+						<left>70</left>
+						<top>0</top>
+						<width>80</width>
+						<height>40</height>
+						<align>center</align>
+						<aligny>center</aligny>
+						<font>font10</font>
+						<textcolor>FFFFFFFF</textcolor>
+						<label>$INFO[Container($VAR[ActiveWidgetID]).ListItem.Rating]</label>
 					</control>
 				</control>
 			</control>
 
-			<!-- Metadata and Description Area -->
+			<!-- Metadata Chips for Shows/Movies: [premiered] [duration] [mpaa] [rating] -->
 			<control type="group">
 				<left>0</left>
-				<top>200</top>
+				<top>450</top>
 				<width>1550</width>
-				<height>350</height>
+				<height>50</height>
+				<visible>String.IsEmpty(Control.GetLabel(8889))</visible>
 
-				<!-- Left Column: Metadata Stack -->
-				<control type="grouplist">
+				<!-- Premiered -->
+				<control type="group">
 					<left>0</left>
 					<top>0</top>
-					<width>250</width>
-					<height>350</height>
-					<orientation>vertical</orientation>
-					<itemgap>12</itemgap>
-					<usecontrolcoords>true</usecontrolcoords>
-
-					<!-- Episode Number (for episodes only) -->
-					<control type="group">
-						<width>200</width>
+					<width>140</width>
+					<height>40</height>
+					<control type="image">
+						<width>140</width>
 						<height>40</height>
-						<visible>!String.IsEmpty(Container($VAR[ActiveWidgetID]).ListItem.Season)</visible>
-						<control type="image">
-							<width>200</width>
-							<height>40</height>
-							<texture colordiffuse="80000000">colors/white.png</texture>
-							<bordersize>2</bordersize>
-							<bordertexture colordiffuse="FFFFFFFF">colors/white.png</bordertexture>
-							<borderradius>4</borderradius>
-						</control>
-						<control type="label">
-							<width>200</width>
-							<height>40</height>
-							<align>center</align>
-							<aligny>center</aligny>
-							<font>font18_title</font>
-							<textcolor>FFFFFFFF</textcolor>
-							<label>$INFO[Container($VAR[ActiveWidgetID]).ListItem.Season,S,]$INFO[Container($VAR[ActiveWidgetID]).ListItem.Episode,E,]</label>
-							<shadowcolor>text_shadow</shadowcolor>
-						</control>
+						<texture colordiffuse="80000000">colors/white.png</texture>
+						<bordersize>2</bordersize>
+						<bordertexture colordiffuse="FFFFFFFF">colors/white.png</bordertexture>
+						<borderradius>4</borderradius>
 					</control>
-
-					<!-- Release Date -->
-					<control type="group">
-						<width>200</width>
+					<control type="label">
+						<width>140</width>
 						<height>40</height>
-						<visible>!String.IsEmpty(Container($VAR[ActiveWidgetID]).ListItem.Premiered)</visible>
-						<control type="image">
-							<width>200</width>
-							<height>40</height>
-							<texture colordiffuse="80000000">colors/white.png</texture>
-							<bordersize>2</bordersize>
-							<bordertexture colordiffuse="FFFFFFFF">colors/white.png</bordertexture>
-							<borderradius>4</borderradius>
-						</control>
-						<control type="label">
-							<width>200</width>
-							<height>40</height>
-							<align>center</align>
-							<aligny>center</aligny>
-							<font>font14</font>
-							<textcolor>FFFFFFFF</textcolor>
-							<label>$INFO[Container($VAR[ActiveWidgetID]).ListItem.Premiered]</label>
-							<shadowcolor>text_shadow</shadowcolor>
-						</control>
-					</control>
-
-					<!-- Runtime -->
-					<control type="group">
-						<width>200</width>
-						<height>40</height>
-						<visible>!String.IsEmpty(Container($VAR[ActiveWidgetID]).ListItem.Duration)</visible>
-						<control type="image">
-							<width>200</width>
-							<height>40</height>
-							<texture colordiffuse="80000000">colors/white.png</texture>
-							<bordersize>2</bordersize>
-							<bordertexture colordiffuse="FFFFFFFF">colors/white.png</bordertexture>
-							<borderradius>4</borderradius>
-						</control>
-						<control type="label">
-							<width>200</width>
-							<height>40</height>
-							<align>center</align>
-							<aligny>center</aligny>
-							<font>font14</font>
-							<textcolor>FFFFFFFF</textcolor>
-							<label>$INFO[Container($VAR[ActiveWidgetID]).ListItem.Duration, min]</label>
-							<shadowcolor>text_shadow</shadowcolor>
-						</control>
-					</control>
-
-					<!-- IMDb Rating Chip -->
-					<control type="group">
-						<width>200</width>
-						<height>40</height>
-						<visible>!String.IsEmpty(Container($VAR[ActiveWidgetID]).ListItem.Rating)</visible>
-
-						<!-- IMDb Logo -->
-						<control type="image">
-							<left>0</left>
-							<top>0</top>
-							<width>60</width>
-							<height>40</height>
-							<texture>imdb_logo.png</texture>
-							<aspectratio>keep</aspectratio>
-						</control>
-
-						<!-- Rating Chip -->
-						<control type="group">
-							<left>70</left>
-							<top>0</top>
-							<width>80</width>
-							<height>40</height>
-							<control type="image">
-								<width>80</width>
-								<height>40</height>
-								<texture colordiffuse="FFF5C518">colors/white.png</texture>
-								<borderradius>20</borderradius>
-							</control>
-							<control type="label">
-								<width>80</width>
-								<height>40</height>
-								<align>center</align>
-								<aligny>center</aligny>
-								<font>font14_title</font>
-								<textcolor>FF000000</textcolor>
-								<label>$INFO[Container($VAR[ActiveWidgetID]).ListItem.Rating]</label>
-							</control>
-						</control>
-					</control>
-
-					<!-- Certification Chip -->
-					<control type="group">
-						<width>200</width>
-						<height>40</height>
-						<visible>!String.IsEmpty(Container($VAR[ActiveWidgetID]).ListItem.Mpaa)</visible>
-						<control type="image">
-							<width>120</width>
-							<height>40</height>
-							<texture colordiffuse="FFDC143C">colors/white.png</texture>
-							<borderradius>20</borderradius>
-						</control>
-						<control type="label">
-							<width>120</width>
-							<height>40</height>
-							<align>center</align>
-							<aligny>center</aligny>
-							<font>font13_title</font>
-							<textcolor>FFFFFFFF</textcolor>
-							<label>$INFO[Container($VAR[ActiveWidgetID]).ListItem.Mpaa]</label>
-						</control>
+						<align>center</align>
+						<aligny>center</aligny>
+						<font>font10</font>
+						<textcolor>FFFFFFFF</textcolor>
+						<label>$INFO[Container($VAR[ActiveWidgetID]).ListItem.Premiered]</label>
 					</control>
 				</control>
 
-				<!-- Right Column: Plot -->
+				<!-- Duration -->
 				<control type="group">
-					<left>270</left>
+					<left>150</left>
 					<top>0</top>
-					<width>1280</width>
-					<height>350</height>
+					<width>120</width>
+					<height>40</height>
+					<control type="image">
+						<width>120</width>
+						<height>40</height>
+						<texture colordiffuse="80000000">colors/white.png</texture>
+						<bordersize>2</bordersize>
+						<bordertexture colordiffuse="FFFFFFFF">colors/white.png</bordertexture>
+						<borderradius>4</borderradius>
+					</control>
+					<control type="label">
+						<width>120</width>
+						<height>40</height>
+						<align>center</align>
+						<aligny>center</aligny>
+						<font>font10</font>
+						<textcolor>FFFFFFFF</textcolor>
+						<label>$INFO[Container($VAR[ActiveWidgetID]).ListItem.Duration, min]</label>
+					</control>
+				</control>
 
-					<!-- Plot -->
-					<control type="textbox">
+				<!-- MPAA/Certification -->
+				<control type="group">
+					<left>280</left>
+					<top>0</top>
+					<width>100</width>
+					<height>40</height>
+					<control type="image">
+						<width>100</width>
+						<height>40</height>
+						<texture colordiffuse="80000000">colors/white.png</texture>
+						<bordersize>2</bordersize>
+						<bordertexture colordiffuse="FFDC143C">colors/white.png</bordertexture>
+						<borderradius>4</borderradius>
+					</control>
+					<control type="label">
+						<width>100</width>
+						<height>40</height>
+						<align>center</align>
+						<aligny>center</aligny>
+						<font>font10</font>
+						<textcolor>FFFFFFFF</textcolor>
+						<label>$INFO[Container($VAR[ActiveWidgetID]).ListItem.Mpaa]</label>
+					</control>
+				</control>
+
+				<!-- IMDb Rating with Logo -->
+				<control type="group">
+					<left>390</left>
+					<top>0</top>
+					<width>150</width>
+					<height>40</height>
+
+					<!-- IMDb Logo -->
+					<control type="image">
 						<left>0</left>
 						<top>0</top>
-						<width>1280</width>
-						<height>350</height>
-						<font>font15</font>
+						<width>60</width>
+						<height>40</height>
+						<texture>imdb_logo.png</texture>
+						<aspectratio>keep</aspectratio>
+					</control>
+
+					<!-- Rating Chip -->
+					<control type="image">
+						<left>70</left>
+						<top>0</top>
+						<width>80</width>
+						<height>40</height>
+						<texture colordiffuse="80000000">colors/white.png</texture>
+						<bordersize>2</bordersize>
+						<bordertexture colordiffuse="FFF5C518">colors/white.png</bordertexture>
+						<borderradius>4</borderradius>
+					</control>
+					<control type="label">
+						<left>70</left>
+						<top>0</top>
+						<width>80</width>
+						<height>40</height>
+						<align>center</align>
+						<aligny>center</aligny>
+						<font>font10</font>
 						<textcolor>FFFFFFFF</textcolor>
-						<label>$VAR[CurrentWidgetPlot]</label>
-						<shadowcolor>text_shadow</shadowcolor>
-						<autoscroll time="3000" delay="4000" repeat="5000">true</autoscroll>
+						<label>$INFO[Container($VAR[ActiveWidgetID]).ListItem.Rating]</label>
 					</control>
 				</control>
 			</control>


### PR DESCRIPTION
- Reduced font size in all metadata chips from font13/14 to font10
- Updated chip backgrounds to transparent black with white/colored borders
- Changed MPAA chip from solid red to transparent with red border
- Changed rating chip from solid yellow to transparent with yellow border
- Set all chip border radius to 4px for consistent rounded corners

- Fixed watchlist/watched button text visibility by reordering controls
- Button text now renders on top of background images

- Fixed browse button modal dialog error by closing search dialogs (1107, 1108)
- Now closes both search pane and info pane before opening browse window

- Enhanced Trakt episode watch status functionality
- Added season and episode parameters for episode-level mark watched/unwatched

- Added genre chips display (max 3) to the right of clearlogo
- Genre chips positioned vertically centered between screen top and description
- Updated genre_splitter to use focused ListItem.Genre for real-time updates