### PR TITLE
AIODI Skin: Button-style metadata chips with dynamic updates and visi…

### DIFF
--- a/skin.AIODI/resources/lib/duration_formatter.py
+++ b/skin.AIODI/resources/lib/duration_formatter.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+Duration formatter for AIODI skin.
+Removes non-numeric characters except colons from duration strings.
+"""
+
+import xbmc
+import xbmcgui
+import re
+
+
+def format_duration(duration_str):
+    """
+    Clean duration string to only contain numbers and colons.
+
+    Args:
+        duration_str: Duration string from Kodi (e.g., "120 min", "1:45:00")
+
+    Returns:
+        Cleaned duration string with only numbers and colons
+    """
+    if not duration_str:
+        return ''
+
+    # Remove everything except digits and colons
+    cleaned = re.sub(r'[^\d:]', '', duration_str)
+
+    return cleaned
+
+
+def set_duration_property():
+    """Get duration from active widget and set cleaned property."""
+    try:
+        # Get the active widget ID
+        active_widget = xbmc.getInfoLabel('Skin.String(ActiveWidgetID)')
+        if not active_widget:
+            return
+
+        # Get duration from the focused item
+        duration = xbmc.getInfoLabel(f'Container({active_widget}).ListItem.Duration')
+
+        # Clean the duration
+        cleaned_duration = format_duration(duration)
+
+        # Set the property
+        win = xbmcgui.Window(10000)
+        win.setProperty('Widget.CleanDuration', cleaned_duration)
+
+    except Exception as e:
+        xbmc.log(f'AIODI Duration Formatter Error: {str(e)}', xbmc.LOGERROR)
+
+
+if __name__ == '__main__':
+    set_duration_property()

--- a/skin.AIODI/xml/DialogVideoInfo.xml
+++ b/skin.AIODI/xml/DialogVideoInfo.xml
@@ -580,6 +580,141 @@
 
 
 
+					<!-- Metadata Section (to right of cast) -->
+					<control type="group">
+						<left>1260</left>
+						<top>0</top>
+						<width>400</width>
+						<height>280</height>
+
+						<!-- Episode Number (for episodes only) -->
+						<control type="button" id="8001">
+							<left>0</left>
+							<top>10</top>
+							<width>120</width>
+							<height>40</height>
+							<font>font10</font>
+							<textcolor>FFFFFFFF</textcolor>
+							<focusedcolor>FFFFFFFF</focusedcolor>
+							<label>$INFO[Window(Home).Property(InfoWindow.Season),S,]$INFO[Window(Home).Property(InfoWindow.Episode),E,]</label>
+							<align>center</align>
+							<aligny>center</aligny>
+							<texturefocus colordiffuse="80000000" border="2,2,2,2">colors/white.png</texturefocus>
+							<texturenofocus colordiffuse="80000000" border="2,2,2,2">colors/white.png</texturenofocus>
+							<bordertexture colordiffuse="FFFFFFFF" border="2">colors/white.png</bordertexture>
+							<bordersize>2</bordersize>
+							<onclick>noop</onclick>
+							<enable>false</enable>
+							<visible>!String.IsEmpty(Window(Home).Property(InfoWindow.Season))</visible>
+						</control>
+
+						<!-- Premiered -->
+						<control type="button" id="8002">
+							<left>0</left>
+							<top>60</top>
+							<width>140</width>
+							<height>40</height>
+							<font>font10</font>
+							<textcolor>FFFFFFFF</textcolor>
+							<focusedcolor>FFFFFFFF</focusedcolor>
+							<label>$INFO[Window(Home).Property(InfoWindow.Premiered)]</label>
+							<align>center</align>
+							<aligny>center</aligny>
+							<texturefocus colordiffuse="80000000" border="2,2,2,2">colors/white.png</texturefocus>
+							<texturenofocus colordiffuse="80000000" border="2,2,2,2">colors/white.png</texturenofocus>
+							<bordertexture colordiffuse="FFFFFFFF" border="2">colors/white.png</bordertexture>
+							<bordersize>2</bordersize>
+							<onclick>noop</onclick>
+							<enable>false</enable>
+							<visible>!String.IsEmpty(Window(Home).Property(InfoWindow.Premiered))</visible>
+						</control>
+
+						<!-- Duration -->
+						<control type="button" id="8003">
+							<left>0</left>
+							<top>110</top>
+							<width>100</width>
+							<height>40</height>
+							<font>font10</font>
+							<textcolor>FFFFFFFF</textcolor>
+							<focusedcolor>FFFFFFFF</focusedcolor>
+							<label>$INFO[Window(Home).Property(InfoWindow.Duration)]</label>
+							<align>center</align>
+							<aligny>center</aligny>
+							<texturefocus colordiffuse="80000000" border="2,2,2,2">colors/white.png</texturefocus>
+							<texturenofocus colordiffuse="80000000" border="2,2,2,2">colors/white.png</texturenofocus>
+							<bordertexture colordiffuse="FFFFFFFF" border="2">colors/white.png</bordertexture>
+							<bordersize>2</bordersize>
+							<onclick>noop</onclick>
+							<enable>false</enable>
+							<visible>!String.IsEmpty(Window(Home).Property(InfoWindow.Duration))</visible>
+						</control>
+
+						<!-- MPAA -->
+						<control type="button" id="8004">
+							<left>0</left>
+							<top>160</top>
+							<width>100</width>
+							<height>40</height>
+							<font>font10</font>
+							<textcolor>FFFFFFFF</textcolor>
+							<focusedcolor>FFFFFFFF</focusedcolor>
+							<label>$INFO[Window(Home).Property(InfoWindow.MPAA)]</label>
+							<align>center</align>
+							<aligny>center</aligny>
+							<texturefocus colordiffuse="80000000" border="2,2,2,2">colors/white.png</texturefocus>
+							<texturenofocus colordiffuse="80000000" border="2,2,2,2">colors/white.png</texturenofocus>
+							<bordertexture colordiffuse="FFDC143C" border="2">colors/white.png</bordertexture>
+							<bordersize>2</bordersize>
+							<onclick>noop</onclick>
+							<enable>false</enable>
+							<visible>!String.IsEmpty(Window(Home).Property(InfoWindow.MPAA))</visible>
+						</control>
+
+						<!-- IMDb Rating -->
+						<control type="group">
+							<left>0</left>
+							<top>210</top>
+							<width>150</width>
+							<height>40</height>
+							<visible>!String.IsEmpty(Window(Home).Property(InfoWindow.Rating))</visible>
+
+							<!-- Rating Chip Background -->
+							<control type="image">
+								<left>0</left>
+								<top>0</top>
+								<width>150</width>
+								<height>40</height>
+								<texture colordiffuse="80000000" border="2,2,2,2">colors/white.png</texture>
+								<bordertexture colordiffuse="FFF5C518" border="2">colors/white.png</bordertexture>
+								<bordersize>2</bordersize>
+							</control>
+
+							<!-- IMDb Logo (inside chip) -->
+							<control type="image">
+								<left>10</left>
+								<top>5</top>
+								<width>60</width>
+								<height>30</height>
+								<texture>imdb_logo.png</texture>
+								<aspectratio>keep</aspectratio>
+							</control>
+
+							<!-- Rating Text -->
+							<control type="label">
+								<left>75</left>
+								<top>0</top>
+								<width>75</width>
+								<height>40</height>
+								<align>center</align>
+								<aligny>center</aligny>
+								<font>font10</font>
+								<textcolor>FFFFFFFF</textcolor>
+								<label>$INFO[Window(Home).Property(InfoWindow.Rating)]</label>
+							</control>
+						</control>
+					</control>
+
 					<!-- Related Content Row -->
 					<control type="label">
 						<left>0</left>

--- a/skin.AIODI/xml/Home.xml
+++ b/skin.AIODI/xml/Home.xml
@@ -219,137 +219,122 @@
 				<visible>!String.IsEmpty(Control.GetLabel(8889))</visible>
 
 				<!-- Episode Number -->
-				<control type="group">
+				<control type="button" id="9901">
 					<left>0</left>
 					<top>0</top>
 					<width>120</width>
 					<height>40</height>
-					<control type="image">
-						<width>120</width>
-						<height>40</height>
-						<texture colordiffuse="80000000">colors/white.png</texture>
-						<bordersize>2</bordersize>
-						<bordertexture colordiffuse="FFFFFFFF">colors/white.png</bordertexture>
-						<borderradius>4</borderradius>
-					</control>
-					<control type="label">
-						<width>120</width>
-						<height>40</height>
-						<align>center</align>
-						<aligny>center</aligny>
-						<font>font10</font>
-						<textcolor>FFFFFFFF</textcolor>
-						<label>$INFO[Container($VAR[ActiveWidgetID]).ListItem.Season,S,]$INFO[Container($VAR[ActiveWidgetID]).ListItem.Episode,E,]</label>
-					</control>
+					<font>font10</font>
+					<textcolor>FFFFFFFF</textcolor>
+					<focusedcolor>FFFFFFFF</focusedcolor>
+					<label>$INFO[Container($VAR[ActiveWidgetID]).ListItem.Season,S,]$INFO[Container($VAR[ActiveWidgetID]).ListItem.Episode,E,]</label>
+					<align>center</align>
+					<aligny>center</aligny>
+					<texturefocus colordiffuse="80000000" border="2,2,2,2">colors/white.png</texturefocus>
+					<texturenofocus colordiffuse="80000000" border="2,2,2,2">colors/white.png</texturenofocus>
+					<bordertexture colordiffuse="FFFFFFFF" border="2">colors/white.png</bordertexture>
+					<bordersize>2</bordersize>
+					<onclick>noop</onclick>
+					<enable>false</enable>
 				</control>
 
 				<!-- Premiered -->
-				<control type="group">
+				<control type="button" id="9902">
 					<left>130</left>
 					<top>0</top>
 					<width>140</width>
 					<height>40</height>
-					<control type="image">
-						<width>140</width>
-						<height>40</height>
-						<texture colordiffuse="80000000">colors/white.png</texture>
-						<bordersize>2</bordersize>
-						<bordertexture colordiffuse="FFFFFFFF">colors/white.png</bordertexture>
-						<borderradius>4</borderradius>
-					</control>
-					<control type="label">
-						<width>140</width>
-						<height>40</height>
-						<align>center</align>
-						<aligny>center</aligny>
-						<font>font10</font>
-						<textcolor>FFFFFFFF</textcolor>
-						<label>$INFO[Container($VAR[ActiveWidgetID]).ListItem.Premiered]</label>
-					</control>
+					<font>font10</font>
+					<textcolor>FFFFFFFF</textcolor>
+					<focusedcolor>FFFFFFFF</focusedcolor>
+					<label>$INFO[Container($VAR[ActiveWidgetID]).ListItem.Premiered]</label>
+					<align>center</align>
+					<aligny>center</aligny>
+					<texturefocus colordiffuse="80000000" border="2,2,2,2">colors/white.png</texturefocus>
+					<texturenofocus colordiffuse="80000000" border="2,2,2,2">colors/white.png</texturenofocus>
+					<bordertexture colordiffuse="FFFFFFFF" border="2">colors/white.png</bordertexture>
+					<bordersize>2</bordersize>
+					<onclick>noop</onclick>
+					<enable>false</enable>
+					<visible>!String.IsEmpty(Container($VAR[ActiveWidgetID]).ListItem.Premiered)</visible>
 				</control>
 
 				<!-- Duration -->
-				<control type="group">
+				<control type="button" id="9903">
 					<left>280</left>
-					<top>0</top>
-					<width>120</width>
-					<height>40</height>
-					<control type="image">
-						<width>120</width>
-						<height>40</height>
-						<texture colordiffuse="80000000">colors/white.png</texture>
-						<bordersize>2</bordersize>
-						<bordertexture colordiffuse="FFFFFFFF">colors/white.png</bordertexture>
-						<borderradius>4</borderradius>
-					</control>
-					<control type="label">
-						<width>120</width>
-						<height>40</height>
-						<align>center</align>
-						<aligny>center</aligny>
-						<font>font10</font>
-						<textcolor>FFFFFFFF</textcolor>
-						<label>$INFO[Container($VAR[ActiveWidgetID]).ListItem.Duration, min]</label>
-					</control>
-				</control>
-
-				<!-- MPAA/Certification -->
-				<control type="group">
-					<left>410</left>
 					<top>0</top>
 					<width>100</width>
 					<height>40</height>
-					<control type="image">
-						<width>100</width>
-						<height>40</height>
-						<texture colordiffuse="80000000">colors/white.png</texture>
-						<bordersize>2</bordersize>
-						<bordertexture colordiffuse="FFDC143C">colors/white.png</bordertexture>
-						<borderradius>4</borderradius>
-					</control>
-					<control type="label">
-						<width>100</width>
-						<height>40</height>
-						<align>center</align>
-						<aligny>center</aligny>
-						<font>font10</font>
-						<textcolor>FFFFFFFF</textcolor>
-						<label>$INFO[Container($VAR[ActiveWidgetID]).ListItem.Mpaa]</label>
-					</control>
+					<font>font10</font>
+					<textcolor>FFFFFFFF</textcolor>
+					<focusedcolor>FFFFFFFF</focusedcolor>
+					<label>$INFO[Container($VAR[ActiveWidgetID]).ListItem.Duration]</label>
+					<align>center</align>
+					<aligny>center</aligny>
+					<texturefocus colordiffuse="80000000" border="2,2,2,2">colors/white.png</texturefocus>
+					<texturenofocus colordiffuse="80000000" border="2,2,2,2">colors/white.png</texturenofocus>
+					<bordertexture colordiffuse="FFFFFFFF" border="2">colors/white.png</bordertexture>
+					<bordersize>2</bordersize>
+					<onclick>noop</onclick>
+					<enable>false</enable>
+					<visible>!String.IsEmpty(Container($VAR[ActiveWidgetID]).ListItem.Duration)</visible>
+				</control>
+
+				<!-- MPAA/Certification -->
+				<control type="button" id="9904">
+					<left>390</left>
+					<top>0</top>
+					<width>100</width>
+					<height>40</height>
+					<font>font10</font>
+					<textcolor>FFFFFFFF</textcolor>
+					<focusedcolor>FFFFFFFF</focusedcolor>
+					<label>$INFO[Container($VAR[ActiveWidgetID]).ListItem.Mpaa]</label>
+					<align>center</align>
+					<aligny>center</aligny>
+					<texturefocus colordiffuse="80000000" border="2,2,2,2">colors/white.png</texturefocus>
+					<texturenofocus colordiffuse="80000000" border="2,2,2,2">colors/white.png</texturenofocus>
+					<bordertexture colordiffuse="FFDC143C" border="2">colors/white.png</bordertexture>
+					<bordersize>2</bordersize>
+					<onclick>noop</onclick>
+					<enable>false</enable>
+					<visible>!String.IsEmpty(Container($VAR[ActiveWidgetID]).ListItem.Mpaa)</visible>
 				</control>
 
 				<!-- IMDb Rating with Logo -->
 				<control type="group">
-					<left>520</left>
+					<left>500</left>
 					<top>0</top>
 					<width>150</width>
 					<height>40</height>
+					<visible>!String.IsEmpty(Container($VAR[ActiveWidgetID]).ListItem.Rating)</visible>
 
-					<!-- IMDb Logo -->
+					<!-- Rating Chip Background -->
 					<control type="image">
 						<left>0</left>
 						<top>0</top>
-						<width>60</width>
+						<width>150</width>
 						<height>40</height>
+						<texture colordiffuse="80000000" border="2,2,2,2">colors/white.png</texture>
+						<bordertexture colordiffuse="FFF5C518" border="2">colors/white.png</bordertexture>
+						<bordersize>2</bordersize>
+					</control>
+
+					<!-- IMDb Logo (inside chip) -->
+					<control type="image">
+						<left>10</left>
+						<top>5</top>
+						<width>60</width>
+						<height>30</height>
 						<texture>imdb_logo.png</texture>
 						<aspectratio>keep</aspectratio>
 					</control>
 
-					<!-- Rating Chip -->
-					<control type="image">
-						<left>70</left>
-						<top>0</top>
-						<width>80</width>
-						<height>40</height>
-						<texture colordiffuse="80000000">colors/white.png</texture>
-						<bordersize>2</bordersize>
-						<bordertexture colordiffuse="FFF5C518">colors/white.png</bordertexture>
-						<borderradius>4</borderradius>
-					</control>
+					<!-- Rating Text -->
 					<control type="label">
-						<left>70</left>
+						<left>75</left>
 						<top>0</top>
-						<width>80</width>
+						<width>75</width>
 						<height>40</height>
 						<align>center</align>
 						<aligny>center</aligny>
@@ -369,112 +354,102 @@
 				<visible>String.IsEmpty(Control.GetLabel(8889))</visible>
 
 				<!-- Premiered -->
-				<control type="group">
+				<control type="button" id="9911">
 					<left>0</left>
 					<top>0</top>
 					<width>140</width>
 					<height>40</height>
-					<control type="image">
-						<width>140</width>
-						<height>40</height>
-						<texture colordiffuse="80000000">colors/white.png</texture>
-						<bordersize>2</bordersize>
-						<bordertexture colordiffuse="FFFFFFFF">colors/white.png</bordertexture>
-						<borderradius>4</borderradius>
-					</control>
-					<control type="label">
-						<width>140</width>
-						<height>40</height>
-						<align>center</align>
-						<aligny>center</aligny>
-						<font>font10</font>
-						<textcolor>FFFFFFFF</textcolor>
-						<label>$INFO[Container($VAR[ActiveWidgetID]).ListItem.Premiered]</label>
-					</control>
+					<font>font10</font>
+					<textcolor>FFFFFFFF</textcolor>
+					<focusedcolor>FFFFFFFF</focusedcolor>
+					<label>$INFO[Container($VAR[ActiveWidgetID]).ListItem.Premiered]</label>
+					<align>center</align>
+					<aligny>center</aligny>
+					<texturefocus colordiffuse="80000000" border="2,2,2,2">colors/white.png</texturefocus>
+					<texturenofocus colordiffuse="80000000" border="2,2,2,2">colors/white.png</texturenofocus>
+					<bordertexture colordiffuse="FFFFFFFF" border="2">colors/white.png</bordertexture>
+					<bordersize>2</bordersize>
+					<onclick>noop</onclick>
+					<enable>false</enable>
+					<visible>!String.IsEmpty(Container($VAR[ActiveWidgetID]).ListItem.Premiered)</visible>
 				</control>
 
 				<!-- Duration -->
-				<control type="group">
+				<control type="button" id="9912">
 					<left>150</left>
-					<top>0</top>
-					<width>120</width>
-					<height>40</height>
-					<control type="image">
-						<width>120</width>
-						<height>40</height>
-						<texture colordiffuse="80000000">colors/white.png</texture>
-						<bordersize>2</bordersize>
-						<bordertexture colordiffuse="FFFFFFFF">colors/white.png</bordertexture>
-						<borderradius>4</borderradius>
-					</control>
-					<control type="label">
-						<width>120</width>
-						<height>40</height>
-						<align>center</align>
-						<aligny>center</aligny>
-						<font>font10</font>
-						<textcolor>FFFFFFFF</textcolor>
-						<label>$INFO[Container($VAR[ActiveWidgetID]).ListItem.Duration, min]</label>
-					</control>
-				</control>
-
-				<!-- MPAA/Certification -->
-				<control type="group">
-					<left>280</left>
 					<top>0</top>
 					<width>100</width>
 					<height>40</height>
-					<control type="image">
-						<width>100</width>
-						<height>40</height>
-						<texture colordiffuse="80000000">colors/white.png</texture>
-						<bordersize>2</bordersize>
-						<bordertexture colordiffuse="FFDC143C">colors/white.png</bordertexture>
-						<borderradius>4</borderradius>
-					</control>
-					<control type="label">
-						<width>100</width>
-						<height>40</height>
-						<align>center</align>
-						<aligny>center</aligny>
-						<font>font10</font>
-						<textcolor>FFFFFFFF</textcolor>
-						<label>$INFO[Container($VAR[ActiveWidgetID]).ListItem.Mpaa]</label>
-					</control>
+					<font>font10</font>
+					<textcolor>FFFFFFFF</textcolor>
+					<focusedcolor>FFFFFFFF</focusedcolor>
+					<label>$INFO[Container($VAR[ActiveWidgetID]).ListItem.Duration]</label>
+					<align>center</align>
+					<aligny>center</aligny>
+					<texturefocus colordiffuse="80000000" border="2,2,2,2">colors/white.png</texturefocus>
+					<texturenofocus colordiffuse="80000000" border="2,2,2,2">colors/white.png</texturenofocus>
+					<bordertexture colordiffuse="FFFFFFFF" border="2">colors/white.png</bordertexture>
+					<bordersize>2</bordersize>
+					<onclick>noop</onclick>
+					<enable>false</enable>
+					<visible>!String.IsEmpty(Container($VAR[ActiveWidgetID]).ListItem.Duration)</visible>
+				</control>
+
+				<!-- MPAA/Certification -->
+				<control type="button" id="9913">
+					<left>260</left>
+					<top>0</top>
+					<width>100</width>
+					<height>40</height>
+					<font>font10</font>
+					<textcolor>FFFFFFFF</textcolor>
+					<focusedcolor>FFFFFFFF</focusedcolor>
+					<label>$INFO[Container($VAR[ActiveWidgetID]).ListItem.Mpaa]</label>
+					<align>center</align>
+					<aligny>center</aligny>
+					<texturefocus colordiffuse="80000000" border="2,2,2,2">colors/white.png</texturefocus>
+					<texturenofocus colordiffuse="80000000" border="2,2,2,2">colors/white.png</texturenofocus>
+					<bordertexture colordiffuse="FFDC143C" border="2">colors/white.png</bordertexture>
+					<bordersize>2</bordersize>
+					<onclick>noop</onclick>
+					<enable>false</enable>
+					<visible>!String.IsEmpty(Container($VAR[ActiveWidgetID]).ListItem.Mpaa)</visible>
 				</control>
 
 				<!-- IMDb Rating with Logo -->
 				<control type="group">
-					<left>390</left>
+					<left>370</left>
 					<top>0</top>
 					<width>150</width>
 					<height>40</height>
+					<visible>!String.IsEmpty(Container($VAR[ActiveWidgetID]).ListItem.Rating)</visible>
 
-					<!-- IMDb Logo -->
+					<!-- Rating Chip Background -->
 					<control type="image">
 						<left>0</left>
 						<top>0</top>
-						<width>60</width>
+						<width>150</width>
 						<height>40</height>
+						<texture colordiffuse="80000000" border="2,2,2,2">colors/white.png</texture>
+						<bordertexture colordiffuse="FFF5C518" border="2">colors/white.png</bordertexture>
+						<bordersize>2</bordersize>
+					</control>
+
+					<!-- IMDb Logo (inside chip) -->
+					<control type="image">
+						<left>10</left>
+						<top>5</top>
+						<width>60</width>
+						<height>30</height>
 						<texture>imdb_logo.png</texture>
 						<aspectratio>keep</aspectratio>
 					</control>
 
-					<!-- Rating Chip -->
-					<control type="image">
-						<left>70</left>
-						<top>0</top>
-						<width>80</width>
-						<height>40</height>
-						<texture colordiffuse="80000000">colors/white.png</texture>
-						<bordersize>2</bordersize>
-						<bordertexture colordiffuse="FFF5C518">colors/white.png</bordertexture>
-						<borderradius>4</borderradius>
-					</control>
+					<!-- Rating Text -->
 					<control type="label">
-						<left>70</left>
+						<left>75</left>
 						<top>0</top>
-						<width>80</width>
+						<width>75</width>
 						<height>40</height>
 						<align>center</align>
 						<aligny>center</aligny>

--- a/skin.AIODI/xml/Includes_Home.xml
+++ b/skin.AIODI/xml/Includes_Home.xml
@@ -406,6 +406,8 @@
 					<onclick condition="!String.IsEqual($PARAM[onclick_action],noop) + !String.IsEmpty($PARAM[onclick_action])">$PARAM[onclick_action]</onclick>
 					<onfocus>Skin.SetString(ActiveWidgetID,$PARAM[list_id])</onfocus>
 					<onfocus>RunScript(special://skin/resources/lib/genre_splitter.py)</onfocus>
+					<onscrollnext>RunScript(special://skin/resources/lib/genre_splitter.py)</onscrollnext>
+					<onscrollprevious>RunScript(special://skin/resources/lib/genre_splitter.py)</onscrollprevious>
 
 					<!-- LANDSCAPE LAYOUT (Episodes) -->
 					<itemlayout width="410" height="360" condition="String.IsEqual(ListItem.DBType,episode)">


### PR DESCRIPTION
…bility

Home.xml metadata chips:
- Converted all chips from image+label groups to button controls for consistency
- Added visibility conditions to hide empty chips (premiered, duration, mpaa, rating)
- Moved IMDb logo inside rating chip border (left-aligned within chip)
- Removed " min" suffix from duration labels (shows raw duration value only)
- Updated rating chip background to transparent with yellow border
- Repositioned chips after moving to button layout

DialogVideoInfo.xml metadata section:
- Added metadata chips to right of cast area (left: 1260px)
- Displays: Episode number (if episode), Premiered, Duration, MPAA, Rating with IMDb logo
- Uses same button-style chip layout as home screen for consistency
- Each chip has visibility condition to hide when empty
- All chips use Window(Home).Property(InfoWindow.*) values

Includes_Home.xml dynamic updates:
- Added onscrollnext and onscrollprevious triggers for genre_splitter.py
- Genres now update dynamically as user scrolls through widget items
- Fixes issue where genres only updated on initial focus

duration_formatter.py (new file):
- Created helper script to clean duration strings
- Removes all non-numeric characters except colons
- Currently unused but available for future duration formatting needs