### PR TITLE
AIODI Skin: Fix all metadata chips to match working S01E02 format

### DIFF
--- a/skin.AIODI/resources/lib/genre_splitter.py
+++ b/skin.AIODI/resources/lib/genre_splitter.py
@@ -10,11 +10,16 @@ import sys
 def split_genres():
     """Split genre string from focused widget item into individual genres (max 3)."""
     try:
-        # Get genre string from the currently focused list item
-        # When called from onfocus, ListItem refers to the focused item
-        genre_string = xbmc.getInfoLabel('ListItem.Genre')
+        # Get the active widget ID
+        active_widget = xbmc.getInfoLabel('Skin.String(ActiveWidgetID)')
 
         win = xbmcgui.Window(10000)
+
+        # Get genre string from the currently focused item in the active widget
+        if active_widget:
+            genre_string = xbmc.getInfoLabel(f'Container({active_widget}).ListItem.Genre')
+        else:
+            genre_string = xbmc.getInfoLabel('ListItem.Genre')
 
         # Clear previous genres
         for i in range(1, 4):

--- a/skin.AIODI/xml/DialogVideoInfo.xml
+++ b/skin.AIODI/xml/DialogVideoInfo.xml
@@ -596,7 +596,7 @@
 							<font>font10</font>
 							<textcolor>FFFFFFFF</textcolor>
 							<focusedcolor>FFFFFFFF</focusedcolor>
-							<label>$INFO[Window(Home).Property(InfoWindow.Season),S,]$INFO[Window(Home).Property(InfoWindow.Episode),E,]</label>
+							<label>$INFO[ListItem.Season,S,]$INFO[ListItem.Episode,E,]</label>
 							<align>center</align>
 							<aligny>center</aligny>
 							<texturefocus colordiffuse="80000000" border="2,2,2,2">colors/white.png</texturefocus>
@@ -605,7 +605,6 @@
 							<bordersize>2</bordersize>
 							<onclick>noop</onclick>
 							<enable>false</enable>
-							<visible>!String.IsEmpty(Window(Home).Property(InfoWindow.Season))</visible>
 						</control>
 
 						<!-- Premiered -->
@@ -617,7 +616,7 @@
 							<font>font10</font>
 							<textcolor>FFFFFFFF</textcolor>
 							<focusedcolor>FFFFFFFF</focusedcolor>
-							<label>$INFO[Window(Home).Property(InfoWindow.Premiered)]</label>
+							<label>$INFO[ListItem.Premiered]</label>
 							<align>center</align>
 							<aligny>center</aligny>
 							<texturefocus colordiffuse="80000000" border="2,2,2,2">colors/white.png</texturefocus>
@@ -626,7 +625,6 @@
 							<bordersize>2</bordersize>
 							<onclick>noop</onclick>
 							<enable>false</enable>
-							<visible>!String.IsEmpty(Window(Home).Property(InfoWindow.Premiered))</visible>
 						</control>
 
 						<!-- Duration -->
@@ -638,7 +636,7 @@
 							<font>font10</font>
 							<textcolor>FFFFFFFF</textcolor>
 							<focusedcolor>FFFFFFFF</focusedcolor>
-							<label>$INFO[Window(Home).Property(InfoWindow.Duration)]</label>
+							<label>$INFO[ListItem.Duration]</label>
 							<align>center</align>
 							<aligny>center</aligny>
 							<texturefocus colordiffuse="80000000" border="2,2,2,2">colors/white.png</texturefocus>
@@ -647,7 +645,6 @@
 							<bordersize>2</bordersize>
 							<onclick>noop</onclick>
 							<enable>false</enable>
-							<visible>!String.IsEmpty(Window(Home).Property(InfoWindow.Duration))</visible>
 						</control>
 
 						<!-- MPAA -->
@@ -659,7 +656,7 @@
 							<font>font10</font>
 							<textcolor>FFFFFFFF</textcolor>
 							<focusedcolor>FFFFFFFF</focusedcolor>
-							<label>$INFO[Window(Home).Property(InfoWindow.MPAA)]</label>
+							<label>$INFO[ListItem.Mpaa]</label>
 							<align>center</align>
 							<aligny>center</aligny>
 							<texturefocus colordiffuse="80000000" border="2,2,2,2">colors/white.png</texturefocus>
@@ -668,50 +665,37 @@
 							<bordersize>2</bordersize>
 							<onclick>noop</onclick>
 							<enable>false</enable>
-							<visible>!String.IsEmpty(Window(Home).Property(InfoWindow.MPAA))</visible>
 						</control>
 
 						<!-- IMDb Rating -->
-						<control type="group">
+						<control type="button" id="8005">
 							<left>0</left>
 							<top>210</top>
 							<width>150</width>
 							<height>40</height>
-							<visible>!String.IsEmpty(Window(Home).Property(InfoWindow.Rating))</visible>
+							<font>font10</font>
+							<textcolor>FFFFFFFF</textcolor>
+							<focusedcolor>FFFFFFFF</focusedcolor>
+							<textoffsetx>75</textoffsetx>
+							<label>$INFO[ListItem.Rating]</label>
+							<align>center</align>
+							<aligny>center</aligny>
+							<texturefocus colordiffuse="80000000" border="2,2,2,2">colors/white.png</texturefocus>
+							<texturenofocus colordiffuse="80000000" border="2,2,2,2">colors/white.png</texturenofocus>
+							<bordertexture colordiffuse="FFF5C518" border="2">colors/white.png</bordertexture>
+							<bordersize>2</bordersize>
+							<onclick>noop</onclick>
+							<enable>false</enable>
+						</control>
 
-							<!-- Rating Chip Background -->
-							<control type="image">
-								<left>0</left>
-								<top>0</top>
-								<width>150</width>
-								<height>40</height>
-								<texture colordiffuse="80000000" border="2,2,2,2">colors/white.png</texture>
-								<bordertexture colordiffuse="FFF5C518" border="2">colors/white.png</bordertexture>
-								<bordersize>2</bordersize>
-							</control>
-
-							<!-- IMDb Logo (inside chip) -->
-							<control type="image">
-								<left>10</left>
-								<top>5</top>
-								<width>60</width>
-								<height>30</height>
-								<texture>imdb_logo.png</texture>
-								<aspectratio>keep</aspectratio>
-							</control>
-
-							<!-- Rating Text -->
-							<control type="label">
-								<left>75</left>
-								<top>0</top>
-								<width>75</width>
-								<height>40</height>
-								<align>center</align>
-								<aligny>center</aligny>
-								<font>font10</font>
-								<textcolor>FFFFFFFF</textcolor>
-								<label>$INFO[Window(Home).Property(InfoWindow.Rating)]</label>
-							</control>
+						<!-- IMDb Logo (overlaid on rating chip) -->
+						<control type="image">
+							<left>10</left>
+							<top>215</top>
+							<width>60</width>
+							<height>30</height>
+							<texture>imdb_logo.png</texture>
+							<aspectratio>keep</aspectratio>
 						</control>
 					</control>
 

--- a/skin.AIODI/xml/Home.xml
+++ b/skin.AIODI/xml/Home.xml
@@ -120,81 +120,63 @@
 
 			<!-- Genre Chips (to the right of clearlogo, vertically centered) -->
 			<!-- Genre 1 -->
-			<control type="group">
+			<control type="button" id="9920">
 				<left>520</left>
 				<top>30</top>
 				<width>180</width>
 				<height>40</height>
-				<visible>!String.IsEmpty(Window(Home).Property(Widget.Genre.1))</visible>
-				<control type="image">
-					<width>180</width>
-					<height>40</height>
-					<texture colordiffuse="80000000">colors/white.png</texture>
-					<bordersize>2</bordersize>
-					<bordertexture colordiffuse="FFFFFFFF">colors/white.png</bordertexture>
-					<borderradius>4</borderradius>
-				</control>
-				<control type="label">
-					<width>180</width>
-					<height>40</height>
-					<align>center</align>
-					<aligny>center</aligny>
-					<font>font10</font>
-					<textcolor>FFFFFFFF</textcolor>
-					<label>$INFO[Window(Home).Property(Widget.Genre.1)]</label>
-				</control>
+				<font>font10</font>
+				<textcolor>FFFFFFFF</textcolor>
+				<focusedcolor>FFFFFFFF</focusedcolor>
+				<label>$INFO[Window(Home).Property(Widget.Genre.1)]</label>
+				<align>center</align>
+				<aligny>center</aligny>
+				<texturefocus colordiffuse="80000000" border="2,2,2,2">colors/white.png</texturefocus>
+				<texturenofocus colordiffuse="80000000" border="2,2,2,2">colors/white.png</texturenofocus>
+				<bordertexture colordiffuse="FFFFFFFF" border="2">colors/white.png</bordertexture>
+				<bordersize>2</bordersize>
+				<onclick>noop</onclick>
+				<enable>false</enable>
 			</control>
 
 			<!-- Genre 2 -->
-			<control type="group">
+			<control type="button" id="9921">
 				<left>520</left>
 				<top>75</top>
 				<width>180</width>
 				<height>40</height>
-				<visible>!String.IsEmpty(Window(Home).Property(Widget.Genre.2))</visible>
-				<control type="image">
-					<width>180</width>
-					<height>40</height>
-					<texture colordiffuse="80000000">colors/white.png</texture>
-					<bordersize>2</bordersize>
-					<bordertexture colordiffuse="FFFFFFFF">colors/white.png</bordertexture>
-					<borderradius>4</borderradius>
-				</control>
-				<control type="label">
-					<width>180</width>
-					<height>40</height>
-					<align>center</align>
-					<aligny>center</aligny>
-					<font>font10</font>
-					<textcolor>FFFFFFFF</textcolor>
-					<label>$INFO[Window(Home).Property(Widget.Genre.2)]</label>
-				</control>
+				<font>font10</font>
+				<textcolor>FFFFFFFF</textcolor>
+				<focusedcolor>FFFFFFFF</focusedcolor>
+				<label>$INFO[Window(Home).Property(Widget.Genre.2)]</label>
+				<align>center</align>
+				<aligny>center</aligny>
+				<texturefocus colordiffuse="80000000" border="2,2,2,2">colors/white.png</texturefocus>
+				<texturenofocus colordiffuse="80000000" border="2,2,2,2">colors/white.png</texturenofocus>
+				<bordertexture colordiffuse="FFFFFFFF" border="2">colors/white.png</bordertexture>
+				<bordersize>2</bordersize>
+				<onclick>noop</onclick>
+				<enable>false</enable>
 			</control>
 
 			<!-- Genre 3 -->
-			<control type="group">
+			<control type="button" id="9922">
 				<left>520</left>
 				<top>120</top>
 				<width>180</width>
 				<height>40</height>
-				<visible>!String.IsEmpty(Window(Home).Property(Widget.Genre.3))</visible>
-				<control type="image">
-					<width>180</width>
-					<height>40</height>
-					<texture colordiffuse="80000000">colors/white.png</texture>
-					<bordersize>2</bordersize>
-					<bordertexture colordiffuse="FFFFFFFF">colors/white.png</bordertexture>
-					<borderradius>4</borderradius>
-				</control>
-				<control type="label">
-					<width>180</width>
-					<height>40</height>
-					<align>center</align>
-					<aligny>center</aligny>
-					<font>font10</font>
-					<textcolor>FFFFFFFF</textcolor>
-					<label>$INFO[Window(Home).Property(Widget.Genre.3)]</label>
-				</control>
+				<font>font10</font>
+				<textcolor>FFFFFFFF</textcolor>
+				<focusedcolor>FFFFFFFF</focusedcolor>
+				<label>$INFO[Window(Home).Property(Widget.Genre.3)]</label>
+				<align>center</align>
+				<aligny>center</aligny>
+				<texturefocus colordiffuse="80000000" border="2,2,2,2">colors/white.png</texturefocus>
+				<texturenofocus colordiffuse="80000000" border="2,2,2,2">colors/white.png</texturenofocus>
+				<bordertexture colordiffuse="FFFFFFFF" border="2">colors/white.png</bordertexture>
+				<bordersize>2</bordersize>
+				<onclick>noop</onclick>
+				<enable>false</enable>
 			</control>
 
 			<!-- Plot Description (aligned with clearlogo) -->
@@ -256,7 +238,6 @@
 					<bordersize>2</bordersize>
 					<onclick>noop</onclick>
 					<enable>false</enable>
-					<visible>!String.IsEmpty(Container($VAR[ActiveWidgetID]).ListItem.Premiered)</visible>
 				</control>
 
 				<!-- Duration -->
@@ -277,7 +258,6 @@
 					<bordersize>2</bordersize>
 					<onclick>noop</onclick>
 					<enable>false</enable>
-					<visible>!String.IsEmpty(Container($VAR[ActiveWidgetID]).ListItem.Duration)</visible>
 				</control>
 
 				<!-- MPAA/Certification -->
@@ -298,50 +278,37 @@
 					<bordersize>2</bordersize>
 					<onclick>noop</onclick>
 					<enable>false</enable>
-					<visible>!String.IsEmpty(Container($VAR[ActiveWidgetID]).ListItem.Mpaa)</visible>
 				</control>
 
 				<!-- IMDb Rating with Logo -->
-				<control type="group">
+				<control type="button" id="9905">
 					<left>500</left>
 					<top>0</top>
 					<width>150</width>
 					<height>40</height>
-					<visible>!String.IsEmpty(Container($VAR[ActiveWidgetID]).ListItem.Rating)</visible>
+					<font>font10</font>
+					<textcolor>FFFFFFFF</textcolor>
+					<focusedcolor>FFFFFFFF</focusedcolor>
+					<textoffsetx>75</textoffsetx>
+					<label>$INFO[Container($VAR[ActiveWidgetID]).ListItem.Rating]</label>
+					<align>center</align>
+					<aligny>center</aligny>
+					<texturefocus colordiffuse="80000000" border="2,2,2,2">colors/white.png</texturefocus>
+					<texturenofocus colordiffuse="80000000" border="2,2,2,2">colors/white.png</texturenofocus>
+					<bordertexture colordiffuse="FFF5C518" border="2">colors/white.png</bordertexture>
+					<bordersize>2</bordersize>
+					<onclick>noop</onclick>
+					<enable>false</enable>
+				</control>
 
-					<!-- Rating Chip Background -->
-					<control type="image">
-						<left>0</left>
-						<top>0</top>
-						<width>150</width>
-						<height>40</height>
-						<texture colordiffuse="80000000" border="2,2,2,2">colors/white.png</texture>
-						<bordertexture colordiffuse="FFF5C518" border="2">colors/white.png</bordertexture>
-						<bordersize>2</bordersize>
-					</control>
-
-					<!-- IMDb Logo (inside chip) -->
-					<control type="image">
-						<left>10</left>
-						<top>5</top>
-						<width>60</width>
-						<height>30</height>
-						<texture>imdb_logo.png</texture>
-						<aspectratio>keep</aspectratio>
-					</control>
-
-					<!-- Rating Text -->
-					<control type="label">
-						<left>75</left>
-						<top>0</top>
-						<width>75</width>
-						<height>40</height>
-						<align>center</align>
-						<aligny>center</aligny>
-						<font>font10</font>
-						<textcolor>FFFFFFFF</textcolor>
-						<label>$INFO[Container($VAR[ActiveWidgetID]).ListItem.Rating]</label>
-					</control>
+				<!-- IMDb Logo (overlaid on rating chip) -->
+				<control type="image">
+					<left>510</left>
+					<top>5</top>
+					<width>60</width>
+					<height>30</height>
+					<texture>imdb_logo.png</texture>
+					<aspectratio>keep</aspectratio>
 				</control>
 			</control>
 
@@ -371,7 +338,6 @@
 					<bordersize>2</bordersize>
 					<onclick>noop</onclick>
 					<enable>false</enable>
-					<visible>!String.IsEmpty(Container($VAR[ActiveWidgetID]).ListItem.Premiered)</visible>
 				</control>
 
 				<!-- Duration -->
@@ -392,7 +358,6 @@
 					<bordersize>2</bordersize>
 					<onclick>noop</onclick>
 					<enable>false</enable>
-					<visible>!String.IsEmpty(Container($VAR[ActiveWidgetID]).ListItem.Duration)</visible>
 				</control>
 
 				<!-- MPAA/Certification -->
@@ -413,50 +378,37 @@
 					<bordersize>2</bordersize>
 					<onclick>noop</onclick>
 					<enable>false</enable>
-					<visible>!String.IsEmpty(Container($VAR[ActiveWidgetID]).ListItem.Mpaa)</visible>
 				</control>
 
 				<!-- IMDb Rating with Logo -->
-				<control type="group">
+				<control type="button" id="9914">
 					<left>370</left>
 					<top>0</top>
 					<width>150</width>
 					<height>40</height>
-					<visible>!String.IsEmpty(Container($VAR[ActiveWidgetID]).ListItem.Rating)</visible>
+					<font>font10</font>
+					<textcolor>FFFFFFFF</textcolor>
+					<focusedcolor>FFFFFFFF</focusedcolor>
+					<textoffsetx>75</textoffsetx>
+					<label>$INFO[Container($VAR[ActiveWidgetID]).ListItem.Rating]</label>
+					<align>center</align>
+					<aligny>center</aligny>
+					<texturefocus colordiffuse="80000000" border="2,2,2,2">colors/white.png</texturefocus>
+					<texturenofocus colordiffuse="80000000" border="2,2,2,2">colors/white.png</texturenofocus>
+					<bordertexture colordiffuse="FFF5C518" border="2">colors/white.png</bordertexture>
+					<bordersize>2</bordersize>
+					<onclick>noop</onclick>
+					<enable>false</enable>
+				</control>
 
-					<!-- Rating Chip Background -->
-					<control type="image">
-						<left>0</left>
-						<top>0</top>
-						<width>150</width>
-						<height>40</height>
-						<texture colordiffuse="80000000" border="2,2,2,2">colors/white.png</texture>
-						<bordertexture colordiffuse="FFF5C518" border="2">colors/white.png</bordertexture>
-						<bordersize>2</bordersize>
-					</control>
-
-					<!-- IMDb Logo (inside chip) -->
-					<control type="image">
-						<left>10</left>
-						<top>5</top>
-						<width>60</width>
-						<height>30</height>
-						<texture>imdb_logo.png</texture>
-						<aspectratio>keep</aspectratio>
-					</control>
-
-					<!-- Rating Text -->
-					<control type="label">
-						<left>75</left>
-						<top>0</top>
-						<width>75</width>
-						<height>40</height>
-						<align>center</align>
-						<aligny>center</aligny>
-						<font>font10</font>
-						<textcolor>FFFFFFFF</textcolor>
-						<label>$INFO[Container($VAR[ActiveWidgetID]).ListItem.Rating]</label>
-					</control>
+				<!-- IMDb Logo (overlaid on rating chip) -->
+				<control type="image">
+					<left>380</left>
+					<top>5</top>
+					<width>60</width>
+					<height>30</height>
+					<texture>imdb_logo.png</texture>
+					<aspectratio>keep</aspectratio>
 				</control>
 			</control>
 		</control>


### PR DESCRIPTION
Home.xml metadata chip fixes:
- Removed individual visibility conditions from all chips (caused rendering issues)
- Converted all chips to button controls matching S01E02 format
- All chips now use same button styling with enable=false
- Episode chips: Episode number, Premiered, Duration, MPAA, Rating
- Show/Movie chips: Premiered, Duration, MPAA, Rating
- IMDb logo overlaid on rating button (left offset for Episodes: 510px, Movies: 380px)
- Rating button uses textoffsetx=75 to position text right of logo
- Yellow border for rating, red for MPAA, white for all others

Genre chip updates:
- Converted genre chips from image+label groups to button controls
- Uses identical button format as metadata chips
- Three genre buttons (ids: 9920, 9921, 9922) at left: 520px
- Vertical positioning: top 30px, 75px, 120px

genre_splitter.py dynamic update fix:
- Changed from ListItem.Genre to Container({active_widget}).ListItem.Genre
- Now correctly reads genre from focused widget item instead of first item
- Fixes issue where genres stayed on first item when scrolling

DialogVideoInfo.xml metadata panel:
- Changed all Window(Home).Property(InfoWindow.*) to ListItem properties
- Removed individual visibility conditions (same fix as home screen)
- Converted rating chip to button control matching home screen format
- IMDb logo overlaid at left: 10px, top: 215px
- All chips now display using available ListItem metadata