### PR TITLE
AIODI Skin: Chip repositioning and width adjustments

### DIFF
--- a/skin.AIODI/xml/DialogVideoInfo.xml
+++ b/skin.AIODI/xml/DialogVideoInfo.xml
@@ -582,7 +582,7 @@
 
 					<!-- Metadata Section (to right of cast) -->
 					<control type="group">
-						<left>1060</left>
+						<left>1010</left>
 						<top>0</top>
 						<width>400</width>
 						<height>280</height>
@@ -591,7 +591,7 @@
 						<control type="button" id="8001">
 							<left>0</left>
 							<top>10</top>
-							<width>120</width>
+							<width>144</width>
 							<height>40</height>
 							<font>font10</font>
 							<textcolor>FFFFFFFF</textcolor>
@@ -611,7 +611,7 @@
 						<control type="button" id="8002">
 							<left>0</left>
 							<top>60</top>
-							<width>140</width>
+							<width>168</width>
 							<height>40</height>
 							<font>font10</font>
 							<textcolor>FFFFFFFF</textcolor>
@@ -631,7 +631,7 @@
 						<control type="button" id="8003">
 							<left>0</left>
 							<top>110</top>
-							<width>100</width>
+							<width>120</width>
 							<height>40</height>
 							<font>font10</font>
 							<textcolor>FFFFFFFF</textcolor>
@@ -651,7 +651,7 @@
 						<control type="button" id="8004">
 							<left>0</left>
 							<top>160</top>
-							<width>100</width>
+							<width>120</width>
 							<height>40</height>
 							<font>font10</font>
 							<textcolor>FFFFFFFF</textcolor>
@@ -671,12 +671,12 @@
 						<control type="button" id="8005">
 							<left>0</left>
 							<top>210</top>
-							<width>150</width>
+							<width>180</width>
 							<height>40</height>
 							<font>font10</font>
 							<textcolor>FFFFFFFF</textcolor>
 							<focusedcolor>FFFFFFFF</focusedcolor>
-							<textoffsetx>75</textoffsetx>
+							<textoffsetx>90</textoffsetx>
 							<label>$INFO[ListItem.Rating]</label>
 							<align>center</align>
 							<aligny>center</aligny>

--- a/skin.AIODI/xml/Home.xml
+++ b/skin.AIODI/xml/Home.xml
@@ -134,7 +134,7 @@
 			<!-- Metadata Chips for Episodes: [S01E01] [premiered] [duration] [mpaa] [rating] -->
 			<control type="group">
 				<left>0</left>
-				<top>450</top>
+				<top>400</top>
 				<width>1550</width>
 				<height>50</height>
 				<visible>!String.IsEmpty(Control.GetLabel(8889))</visible>
@@ -254,7 +254,7 @@
 			<!-- Metadata Chips for Shows/Movies: [premiered] [duration] [mpaa] [rating] -->
 			<control type="group">
 				<left>0</left>
-				<top>450</top>
+				<top>400</top>
 				<width>1550</width>
 				<height>50</height>
 				<visible>String.IsEmpty(Control.GetLabel(8889))</visible>
@@ -354,7 +354,7 @@
 			<!-- Genre Chip (single wide chip below metadata) -->
 			<control type="button" id="9930">
 				<left>0</left>
-				<top>500</top>
+				<top>450</top>
 				<width>700</width>
 				<height>40</height>
 				<font>font10</font>


### PR DESCRIPTION
Home.xml chip positioning:
- Moved metadata chips up 50px (top: 450 → 400)
- Moved genre chip up 50px (top: 500 → 450)
- Applies to both episode and show/movie metadata groups

DialogVideoInfo.xml info panel updates:
- Moved metadata section left 50px (left: 1060 → 1010)
- Increased all chip widths by 20%:
  * Episode Number: 120px → 144px
  * Premiered: 140px → 168px
  * Duration: 100px → 120px
  * MPAA: 100px → 120px
  * Rating: 150px → 180px
- Adjusted rating chip textoffsetx from 75 to 90 to accommodate wider chip