### PR TITLE
Fix IMDb rating display and implement 3 genre chips

### DIFF
--- a/plugin.video.aiostreams/addon.py
+++ b/plugin.video.aiostreams/addon.py
@@ -865,7 +865,7 @@ def create_listitem_with_context(meta, content_type, action_url):
     imdb_rating = meta.get('imdbRating', '')
     if imdb_rating:
         try:
-            info_tag.setRating(float(imdb_rating), votes=0, defaultt=True)
+            info_tag.setRating(float(imdb_rating), votes=0, default=True)
             info_tag.setIMDBNumber(meta.get('imdb_id', meta.get('id', '')))
         except:
             pass

--- a/skin.AIODI/resources/lib/genre_splitter.py
+++ b/skin.AIODI/resources/lib/genre_splitter.py
@@ -1,10 +1,11 @@
 """
 Helper script to split genre strings into individual genres (max 3).
 Sets window properties for display in skin.
+Works with AIOStreams plugin which provides genres as comma/slash/ampersand separated string.
 """
 import xbmc
 import xbmcgui
-import sys
+import re
 
 
 def split_genres():
@@ -26,10 +27,11 @@ def split_genres():
             win.clearProperty(f'Widget.Genre.{i}')
 
         if not genre_string:
+            xbmc.log('[GenreSplitter] No genre string found', xbmc.LOGDEBUG)
             return
 
         # Split by common delimiters (/, &, comma)
-        import re
+        # Kodi's setGenres() concatenates genres with " / " by default
         genres = re.split(r'\s*/\s*|\s*&\s*|\s*,\s*', genre_string)
 
         # Remove empty strings and strip whitespace
@@ -39,6 +41,8 @@ def split_genres():
         for i, genre in enumerate(genres[:3], 1):
             win.setProperty(f'Widget.Genre.{i}', genre)
             xbmc.log(f'[GenreSplitter] Set Genre.{i}: {genre}', xbmc.LOGDEBUG)
+
+        xbmc.log(f'[GenreSplitter] Split genre string "{genre_string}" into {len(genres[:3])} genres', xbmc.LOGDEBUG)
 
     except Exception as e:
         xbmc.log(f'[GenreSplitter] Error: {e}', xbmc.LOGERROR)

--- a/skin.AIODI/xml/Home.xml
+++ b/skin.AIODI/xml/Home.xml
@@ -351,24 +351,75 @@
 				</control>
 			</control>
 
-			<!-- Genre Chip (single wide chip below metadata) -->
-			<control type="button" id="9930">
+			<!-- Genre Chips (3 individual chips below metadata) -->
+			<control type="group">
 				<left>0</left>
 				<top>450</top>
-				<width>700</width>
+				<width>1550</width>
 				<height>40</height>
-				<font>font10</font>
-				<textcolor>FFFFFFFF</textcolor>
-				<focusedcolor>FFFFFFFF</focusedcolor>
-				<label>$INFO[Container($VAR[ActiveWidgetID]).ListItem.Genre]</label>
-				<align>center</align>
-				<aligny>center</aligny>
-				<texturefocus colordiffuse="80000000" border="2,2,2,2">colors/white.png</texturefocus>
-				<texturenofocus colordiffuse="80000000" border="2,2,2,2">colors/white.png</texturenofocus>
-				<bordertexture colordiffuse="FFFFFFFF" border="2">colors/white.png</bordertexture>
-				<bordersize>2</bordersize>
-				<onclick>noop</onclick>
-				<enable>false</enable>
+
+				<!-- Genre 1 -->
+				<control type="button" id="9930">
+					<left>0</left>
+					<top>0</top>
+					<width>210</width>
+					<height>40</height>
+					<font>font10</font>
+					<textcolor>FFFFFFFF</textcolor>
+					<focusedcolor>FFFFFFFF</focusedcolor>
+					<label>$INFO[Window(Home).Property(Widget.Genre.1)]</label>
+					<align>center</align>
+					<aligny>center</aligny>
+					<texturefocus colordiffuse="80000000" border="2,2,2,2">colors/white.png</texturefocus>
+					<texturenofocus colordiffuse="80000000" border="2,2,2,2">colors/white.png</texturenofocus>
+					<bordertexture colordiffuse="FFFFFFFF" border="2">colors/white.png</bordertexture>
+					<bordersize>2</bordersize>
+					<onclick>noop</onclick>
+					<enable>false</enable>
+					<visible>!String.IsEmpty(Window(Home).Property(Widget.Genre.1))</visible>
+				</control>
+
+				<!-- Genre 2 -->
+				<control type="button" id="9931">
+					<left>220</left>
+					<top>0</top>
+					<width>210</width>
+					<height>40</height>
+					<font>font10</font>
+					<textcolor>FFFFFFFF</textcolor>
+					<focusedcolor>FFFFFFFF</focusedcolor>
+					<label>$INFO[Window(Home).Property(Widget.Genre.2)]</label>
+					<align>center</align>
+					<aligny>center</aligny>
+					<texturefocus colordiffuse="80000000" border="2,2,2,2">colors/white.png</texturefocus>
+					<texturenofocus colordiffuse="80000000" border="2,2,2,2">colors/white.png</texturenofocus>
+					<bordertexture colordiffuse="FFFFFFFF" border="2">colors/white.png</bordertexture>
+					<bordersize>2</bordersize>
+					<onclick>noop</onclick>
+					<enable>false</enable>
+					<visible>!String.IsEmpty(Window(Home).Property(Widget.Genre.2))</visible>
+				</control>
+
+				<!-- Genre 3 -->
+				<control type="button" id="9932">
+					<left>440</left>
+					<top>0</top>
+					<width>210</width>
+					<height>40</height>
+					<font>font10</font>
+					<textcolor>FFFFFFFF</textcolor>
+					<focusedcolor>FFFFFFFF</focusedcolor>
+					<label>$INFO[Window(Home).Property(Widget.Genre.3)]</label>
+					<align>center</align>
+					<aligny>center</aligny>
+					<texturefocus colordiffuse="80000000" border="2,2,2,2">colors/white.png</texturefocus>
+					<texturenofocus colordiffuse="80000000" border="2,2,2,2">colors/white.png</texturenofocus>
+					<bordertexture colordiffuse="FFFFFFFF" border="2">colors/white.png</bordertexture>
+					<bordersize>2</bordersize>
+					<onclick>noop</onclick>
+					<enable>false</enable>
+					<visible>!String.IsEmpty(Window(Home).Property(Widget.Genre.3))</visible>
+				</control>
 			</control>
 		</control>
 	</control>

--- a/skin.AIODI/xml/Includes_Home.xml
+++ b/skin.AIODI/xml/Includes_Home.xml
@@ -100,6 +100,9 @@
 					<onup>$PARAM[onup_action]</onup>
 					<ondown>$PARAM[ondown_action]</ondown>
 					<onfocus>Skin.SetString(ActiveWidgetID,$PARAM[list_id])</onfocus>
+					<onfocus>RunScript(special://skin/resources/lib/genre_splitter.py)</onfocus>
+					<onscrollnext>RunScript(special://skin/resources/lib/genre_splitter.py)</onscrollnext>
+					<onscrollprevious>RunScript(special://skin/resources/lib/genre_splitter.py)</onscrollprevious>
 					<itemlayout width="240" height="360">
 						<control type="image">
 							<width>230</width>
@@ -242,6 +245,9 @@
 					<onup>$PARAM[onup_action]</onup>
 					<ondown>$PARAM[ondown_action]</ondown>
 					<onfocus>Skin.SetString(ActiveWidgetID,$PARAM[list_id])</onfocus>
+					<onfocus>RunScript(special://skin/resources/lib/genre_splitter.py)</onfocus>
+					<onscrollnext>RunScript(special://skin/resources/lib/genre_splitter.py)</onscrollnext>
+					<onscrollprevious>RunScript(special://skin/resources/lib/genre_splitter.py)</onscrollprevious>
 					<itemlayout width="410" height="235">
 						<control type="image">
 							<width>390</width>
@@ -405,6 +411,9 @@
 					<onclick condition="![String.IsEqual(ListItem.DBType,tvshow) | String.IsEqual(ListItem.DBType,season)] + [String.IsEmpty($PARAM[onclick_action]) | String.IsEqual($PARAM[onclick_action],noop)]">RunScript(special://skin/resources/lib/resume_helper.py)</onclick>
 					<onclick condition="!String.IsEqual($PARAM[onclick_action],noop) + !String.IsEmpty($PARAM[onclick_action])">$PARAM[onclick_action]</onclick>
 					<onfocus>Skin.SetString(ActiveWidgetID,$PARAM[list_id])</onfocus>
+					<onfocus>RunScript(special://skin/resources/lib/genre_splitter.py)</onfocus>
+					<onscrollnext>RunScript(special://skin/resources/lib/genre_splitter.py)</onscrollnext>
+					<onscrollprevious>RunScript(special://skin/resources/lib/genre_splitter.py)</onscrollprevious>
 
 					<!-- LANDSCAPE LAYOUT (Episodes) -->
 					<itemlayout width="410" height="360" condition="String.IsEqual(ListItem.DBType,episode)">
@@ -809,6 +818,9 @@
 					<onclick condition="String.IsEmpty($PARAM[onclick_action]) | String.IsEqual($PARAM[onclick_action],noop)">PlayMedia($INFO[ListItem.FileNameAndPath])</onclick>
 					<onclick condition="!String.IsEmpty($PARAM[onclick_action]) + !String.IsEqual($PARAM[onclick_action],noop)">$PARAM[onclick_action]</onclick>
 					<onfocus>Skin.SetString(ActiveWidgetID,$PARAM[list_id])</onfocus>
+					<onfocus>RunScript(special://skin/resources/lib/genre_splitter.py)</onfocus>
+					<onscrollnext>RunScript(special://skin/resources/lib/genre_splitter.py)</onscrollnext>
+					<onscrollprevious>RunScript(special://skin/resources/lib/genre_splitter.py)</onscrollprevious>
 					<itemlayout width="410" height="235">
 						<control type="group">
 							<animation effect="zoom" center="auto" start="100" end="110" time="200" tween="sine" easing="out">Focus</animation>


### PR DESCRIPTION
- Fixed rating parameter typo in addon.py (defaultt -> default)
- Replaced single wide genre chip with 3 individual genre chips
- Updated genre_splitter.py to dynamically split genres on widget focus/scroll
- Added genre_splitter.py calls to all widget templates in Includes_Home.xml

This enables:
1. IMDb ratings to display correctly using ListItem.Rating
2. First 3 genres from JSON array to display as individual chips
3. Dynamic genre updates when scrolling through widget items