### PR TITLE
Store genres and rating as ListItem properties, reposition chips

### DIFF
--- a/plugin.video.aiostreams/addon.py
+++ b/plugin.video.aiostreams/addon.py
@@ -797,6 +797,12 @@ def create_listitem_with_context(meta, content_type, action_url):
     genres = meta.get('genres', [])
     if genres:
         info_tag.setGenres(genres)
+        # Also set individual genre properties for skin chips (max 3)
+        for i in range(1, 4):
+            if i <= len(genres):
+                list_item.setProperty(f'Genre{i}', genres[i-1])
+            else:
+                list_item.setProperty(f'Genre{i}', '')
     
     # Add runtime (handle "2h16min", "48min", "120" formats)
     runtime = meta.get('runtime', '')
@@ -865,8 +871,11 @@ def create_listitem_with_context(meta, content_type, action_url):
     imdb_rating = meta.get('imdbRating', '')
     if imdb_rating:
         try:
-            info_tag.setRating(float(imdb_rating), votes=0, default=True)
+            rating_value = float(imdb_rating)
+            info_tag.setRating(rating_value, votes=0, rating_type='imdb', default=True)
             info_tag.setIMDBNumber(meta.get('imdb_id', meta.get('id', '')))
+            # Also set as property for direct skin access
+            list_item.setProperty('IMDbRating', str(rating_value))
         except:
             pass
 

--- a/skin.AIODI/xml/DialogVideoInfo.xml
+++ b/skin.AIODI/xml/DialogVideoInfo.xml
@@ -677,7 +677,7 @@
 							<textcolor>FFFFFFFF</textcolor>
 							<focusedcolor>FFFFFFFF</focusedcolor>
 							<textoffsetx>90</textoffsetx>
-							<label>$INFO[ListItem.Rating]</label>
+							<label>$INFO[ListItem.Property(IMDbRating)]</label>
 							<align>center</align>
 							<aligny>center</aligny>
 							<texturefocus colordiffuse="80000000" border="2,2,2,2">colors/white.png</texturefocus>

--- a/skin.AIODI/xml/Home.xml
+++ b/skin.AIODI/xml/Home.xml
@@ -134,7 +134,7 @@
 			<!-- Metadata Chips for Episodes: [S01E01] [premiered] [duration] [mpaa] [rating] -->
 			<control type="group">
 				<left>0</left>
-				<top>400</top>
+				<top>450</top>
 				<width>1550</width>
 				<height>50</height>
 				<visible>!String.IsEmpty(Control.GetLabel(8889))</visible>
@@ -229,7 +229,7 @@
 					<textcolor>FFFFFFFF</textcolor>
 					<focusedcolor>FFFFFFFF</focusedcolor>
 					<textoffsetx>75</textoffsetx>
-					<label>$INFO[Container($VAR[ActiveWidgetID]).ListItem.Rating]</label>
+					<label>$INFO[Container($VAR[ActiveWidgetID]).ListItem.Property(IMDbRating)]</label>
 					<align>center</align>
 					<aligny>center</aligny>
 					<texturefocus colordiffuse="80000000" border="2,2,2,2">colors/white.png</texturefocus>
@@ -254,7 +254,7 @@
 			<!-- Metadata Chips for Shows/Movies: [premiered] [duration] [mpaa] [rating] -->
 			<control type="group">
 				<left>0</left>
-				<top>400</top>
+				<top>450</top>
 				<width>1550</width>
 				<height>50</height>
 				<visible>String.IsEmpty(Control.GetLabel(8889))</visible>
@@ -329,7 +329,7 @@
 					<textcolor>FFFFFFFF</textcolor>
 					<focusedcolor>FFFFFFFF</focusedcolor>
 					<textoffsetx>75</textoffsetx>
-					<label>$INFO[Container($VAR[ActiveWidgetID]).ListItem.Rating]</label>
+					<label>$INFO[Container($VAR[ActiveWidgetID]).ListItem.Property(IMDbRating)]</label>
 					<align>center</align>
 					<aligny>center</aligny>
 					<texturefocus colordiffuse="80000000" border="2,2,2,2">colors/white.png</texturefocus>
@@ -351,11 +351,11 @@
 				</control>
 			</control>
 
-			<!-- Genre Chips (3 individual chips below metadata) -->
+			<!-- Genre Chips (3 individual chips to the right of clearlogo) -->
 			<control type="group">
-				<left>0</left>
-				<top>450</top>
-				<width>1550</width>
+				<left>510</left>
+				<top>140</top>
+				<width>1000</width>
 				<height>40</height>
 
 				<!-- Genre 1 -->
@@ -367,7 +367,7 @@
 					<font>font10</font>
 					<textcolor>FFFFFFFF</textcolor>
 					<focusedcolor>FFFFFFFF</focusedcolor>
-					<label>$INFO[Window(Home).Property(Widget.Genre.1)]</label>
+					<label>$INFO[Container($VAR[ActiveWidgetID]).ListItem.Property(Genre1)]</label>
 					<align>center</align>
 					<aligny>center</aligny>
 					<texturefocus colordiffuse="80000000" border="2,2,2,2">colors/white.png</texturefocus>
@@ -376,7 +376,7 @@
 					<bordersize>2</bordersize>
 					<onclick>noop</onclick>
 					<enable>false</enable>
-					<visible>!String.IsEmpty(Window(Home).Property(Widget.Genre.1))</visible>
+					<visible>!String.IsEmpty(Container($VAR[ActiveWidgetID]).ListItem.Property(Genre1))</visible>
 				</control>
 
 				<!-- Genre 2 -->
@@ -388,7 +388,7 @@
 					<font>font10</font>
 					<textcolor>FFFFFFFF</textcolor>
 					<focusedcolor>FFFFFFFF</focusedcolor>
-					<label>$INFO[Window(Home).Property(Widget.Genre.2)]</label>
+					<label>$INFO[Container($VAR[ActiveWidgetID]).ListItem.Property(Genre2)]</label>
 					<align>center</align>
 					<aligny>center</aligny>
 					<texturefocus colordiffuse="80000000" border="2,2,2,2">colors/white.png</texturefocus>
@@ -397,7 +397,7 @@
 					<bordersize>2</bordersize>
 					<onclick>noop</onclick>
 					<enable>false</enable>
-					<visible>!String.IsEmpty(Window(Home).Property(Widget.Genre.2))</visible>
+					<visible>!String.IsEmpty(Container($VAR[ActiveWidgetID]).ListItem.Property(Genre2))</visible>
 				</control>
 
 				<!-- Genre 3 -->
@@ -409,7 +409,7 @@
 					<font>font10</font>
 					<textcolor>FFFFFFFF</textcolor>
 					<focusedcolor>FFFFFFFF</focusedcolor>
-					<label>$INFO[Window(Home).Property(Widget.Genre.3)]</label>
+					<label>$INFO[Container($VAR[ActiveWidgetID]).ListItem.Property(Genre3)]</label>
 					<align>center</align>
 					<aligny>center</aligny>
 					<texturefocus colordiffuse="80000000" border="2,2,2,2">colors/white.png</texturefocus>
@@ -418,7 +418,7 @@
 					<bordersize>2</bordersize>
 					<onclick>noop</onclick>
 					<enable>false</enable>
-					<visible>!String.IsEmpty(Window(Home).Property(Widget.Genre.3))</visible>
+					<visible>!String.IsEmpty(Container($VAR[ActiveWidgetID]).ListItem.Property(Genre3))</visible>
 				</control>
 			</control>
 		</control>

--- a/skin.AIODI/xml/Includes_Home.xml
+++ b/skin.AIODI/xml/Includes_Home.xml
@@ -100,9 +100,6 @@
 					<onup>$PARAM[onup_action]</onup>
 					<ondown>$PARAM[ondown_action]</ondown>
 					<onfocus>Skin.SetString(ActiveWidgetID,$PARAM[list_id])</onfocus>
-					<onfocus>RunScript(special://skin/resources/lib/genre_splitter.py)</onfocus>
-					<onscrollnext>RunScript(special://skin/resources/lib/genre_splitter.py)</onscrollnext>
-					<onscrollprevious>RunScript(special://skin/resources/lib/genre_splitter.py)</onscrollprevious>
 					<itemlayout width="240" height="360">
 						<control type="image">
 							<width>230</width>
@@ -245,9 +242,6 @@
 					<onup>$PARAM[onup_action]</onup>
 					<ondown>$PARAM[ondown_action]</ondown>
 					<onfocus>Skin.SetString(ActiveWidgetID,$PARAM[list_id])</onfocus>
-					<onfocus>RunScript(special://skin/resources/lib/genre_splitter.py)</onfocus>
-					<onscrollnext>RunScript(special://skin/resources/lib/genre_splitter.py)</onscrollnext>
-					<onscrollprevious>RunScript(special://skin/resources/lib/genre_splitter.py)</onscrollprevious>
 					<itemlayout width="410" height="235">
 						<control type="image">
 							<width>390</width>
@@ -411,9 +405,6 @@
 					<onclick condition="![String.IsEqual(ListItem.DBType,tvshow) | String.IsEqual(ListItem.DBType,season)] + [String.IsEmpty($PARAM[onclick_action]) | String.IsEqual($PARAM[onclick_action],noop)]">RunScript(special://skin/resources/lib/resume_helper.py)</onclick>
 					<onclick condition="!String.IsEqual($PARAM[onclick_action],noop) + !String.IsEmpty($PARAM[onclick_action])">$PARAM[onclick_action]</onclick>
 					<onfocus>Skin.SetString(ActiveWidgetID,$PARAM[list_id])</onfocus>
-					<onfocus>RunScript(special://skin/resources/lib/genre_splitter.py)</onfocus>
-					<onscrollnext>RunScript(special://skin/resources/lib/genre_splitter.py)</onscrollnext>
-					<onscrollprevious>RunScript(special://skin/resources/lib/genre_splitter.py)</onscrollprevious>
 
 					<!-- LANDSCAPE LAYOUT (Episodes) -->
 					<itemlayout width="410" height="360" condition="String.IsEqual(ListItem.DBType,episode)">
@@ -818,9 +809,6 @@
 					<onclick condition="String.IsEmpty($PARAM[onclick_action]) | String.IsEqual($PARAM[onclick_action],noop)">PlayMedia($INFO[ListItem.FileNameAndPath])</onclick>
 					<onclick condition="!String.IsEmpty($PARAM[onclick_action]) + !String.IsEqual($PARAM[onclick_action],noop)">$PARAM[onclick_action]</onclick>
 					<onfocus>Skin.SetString(ActiveWidgetID,$PARAM[list_id])</onfocus>
-					<onfocus>RunScript(special://skin/resources/lib/genre_splitter.py)</onfocus>
-					<onscrollnext>RunScript(special://skin/resources/lib/genre_splitter.py)</onscrollnext>
-					<onscrollprevious>RunScript(special://skin/resources/lib/genre_splitter.py)</onscrollprevious>
 					<itemlayout width="410" height="235">
 						<control type="group">
 							<animation effect="zoom" center="auto" start="100" end="110" time="200" tween="sine" easing="out">Focus</animation>


### PR DESCRIPTION
Plugin changes (addon.py):
- Set Genre1, Genre2, Genre3 as ListItem properties (max 3 genres)
- Set IMDbRating as ListItem property for direct skin access
- Added rating_type='imdb' parameter to setRating()

Skin changes:
- Moved metadata chips from top:400 to top:450
- Moved genre chips from top:450 to top:140, left:510 (right of clearlogo)
- Updated all rating labels to use ListItem.Property(IMDbRating)
- Updated genre chips to use ListItem.Property(Genre1/2/3)
- Removed all genre_splitter.py script calls from widget templates

This eliminates the need for the genre_splitter helper script by storing genres directly as properties when ListItems are created, and ensures ratings display correctly using the property accessor.