### PR TITLE
Add missing get_color_code_items() function to settings_helpers

### DIFF
--- a/plugin.video.aiostreams/resources/lib/settings_helpers.py
+++ b/plugin.video.aiostreams/resources/lib/settings_helpers.py
@@ -89,6 +89,11 @@ def get_show_quality_badges():
     return get_bool_setting('show_quality_badges', True)
 
 
+def get_color_code_items():
+    """Check if items should be color coded by watch status."""
+    return get_bool_setting('color_code_items', True)
+
+
 def get_cache_expiry_hours():
     """Get cache expiry in hours."""
     return get_int_setting('cache_expiry_hours', 24)


### PR DESCRIPTION
This commit fixes a critical error that prevented browsing TV show seasons:
  "[AIOStreams] Action error (show_seasons): module 'resources.lib.settings_helpers'
   has no attribute 'get_color_code_items'"

The function was being called by ui_helpers.get_watched_color() but was never implemented in settings_helpers.py, even though the 'color_code_items' setting exists in settings.xml.

Added:
- get_color_code_items() function that reads the 'color_code_items' boolean setting
- Defaults to True (color coding enabled) to match settings.xml default

This fixes the show_seasons() action which was failing completely due to this missing function, preventing users from drilling down into TV shows.