### PR TITLE
Fix Trakt Next Up playback - change content_type from 'episode' to 's…

### DIFF
--- a/plugin.video.aiostreams/addon.py
+++ b/plugin.video.aiostreams/addon.py
@@ -3636,7 +3636,7 @@ def trakt_next_up():
                             break
 
             label = f'{show_title} S{season:02d}E{episode:02d}'
-            url = get_url(action='play', content_type='episode', imdb_id=show_imdb, season=season, episode=episode, title=label, poster=poster, fanart=fanart, clearlogo=logo)
+            url = get_url(action='play', content_type='series', imdb_id=show_imdb, season=season, episode=episode, title=label, poster=poster, fanart=fanart, clearlogo=logo)
 
             # Prepare metadata for creation (merging show-level info for chips)
             meta = {


### PR DESCRIPTION
…eries'

This commit fixes the "no streams available" error when playing episodes from the Trakt Next Up list.

Issue:
- Episodes played fine when browsing manually (show > season > episode)
- Episodes from Trakt Next Up failed with "no streams available"

Root cause:
- trakt_next_up() was using content_type='episode' when constructing play URLs
- The play() function and get_meta() expect content_type to be 'movie' or 'series'
- Using 'episode' caused metadata fetching to fail, resulting in no streams

Fix:
- Changed line 3639: content_type='episode' -> content_type='series'
- Now matches how show_episodes() constructs playback URLs (line 3260)
- Ensures proper metadata fetching and stream scraping

Trakt Next Up episodes now play correctly, matching the behavior of manually browsed episodes.