### PR TITLE
Add Trakt watched/unwatched context menu to Next Up episodes

### DIFF
--- a/plugin.video.aiostreams/addon.py
+++ b/plugin.video.aiostreams/addon.py
@@ -3698,6 +3698,19 @@ def trakt_next_up():
             context_menu = []
             context_menu.append(('[COLOR lightcoral]Scrape Streams[/COLOR]', f'RunPlugin({get_url(action="show_streams", content_type="series", media_id=f"{show_imdb}:{season}:{episode}", title=label, poster=poster, fanart=fanart, clearlogo=logo)})'))
             context_menu.append(('[COLOR lightcoral]Browse Show[/COLOR]', f'ActivateWindow(Videos,{get_url(action="show_seasons", meta_id=show_imdb)},return)'))
+
+            # Add Trakt watched toggle for episodes if authorized
+            if HAS_MODULES and trakt.get_access_token() and show_imdb:
+                show_trakt_id = ep_data.get('show_trakt_id')
+                if show_trakt_id:
+                    is_watched = db.is_item_watched(show_trakt_id, 'episode', season, episode)
+                    if is_watched:
+                        context_menu.append(('[COLOR lightcoral]Mark Episode As Unwatched[/COLOR]',
+                                            f'RunPlugin({get_url(action="trakt_mark_unwatched", media_type="show", imdb_id=show_imdb, season=season, episode=episode)})'))
+                    else:
+                        context_menu.append(('[COLOR lightcoral]Mark Episode As Watched[/COLOR]',
+                                            f'RunPlugin({get_url(action="trakt_mark_watched", media_type="show", imdb_id=show_imdb, season=season, episode=episode)})'))
+
             list_item.addContextMenuItems(context_menu)
             list_item.setProperty('IsPlayable', 'true')
 


### PR DESCRIPTION
This commit fixes the "couldn't find Trakt ID" error when marking episodes as watched/unwatched from the Trakt Next Up information panel.

Issue:
- Marking episodes watched/unwatched from Next Up failed with Trakt ID error
- Same action worked fine from show > season > episode browser

Root cause:
- trakt_next_up() was calling create_listitem_with_context() with content_type='episode'
- create_listitem_with_context() only handles 'movie' or 'series', not 'episode'
- This caused it to skip adding Trakt context menu items
- Only 'Scrape Streams' and 'Browse Show' menus were manually added
- 'Mark as Watched/Unwatched' menus were missing entirely

Fix:
- Added episode-specific Trakt watched/unwatched context menu items to trakt_next_up()
- Uses show_trakt_id to check watched status via db.is_item_watched()
- Passes correct parameters: media_type="show", imdb_id, season, episode
- Matches implementation from show_episodes() function

Now users can mark episodes as watched/unwatched from the Next Up list context menu, and from the information panel, matching the behavior of the normal episode browser.