### PR TITLE
Customize info panel for Trakt Next Up - hide watchlist/watched, enab…

### DIFF
--- a/plugin.video.aiostreams/addon.py
+++ b/plugin.video.aiostreams/addon.py
@@ -3658,7 +3658,13 @@ def trakt_next_up():
                     meta['runtime'] = str(meta_data['runtime'])
 
             list_item = create_listitem_with_context(meta, 'episode', url)
-            
+
+            # Mark this as a Next Up episode for special handling in the info panel
+            list_item.setProperty('IsNextUpEpisode', 'true')
+            list_item.setProperty('NextUpShowIMDb', show_imdb)
+            list_item.setProperty('NextUpSeason', str(season))
+            list_item.setProperty('NextUpEpisode', str(episode))
+
             # InfoTag cleanup
             info_tag = list_item.getVideoInfoTag()
             info_tag.setTitle(episode_title)

--- a/skin.AIODI/xml/DialogVideoInfo.xml
+++ b/skin.AIODI/xml/DialogVideoInfo.xml
@@ -93,6 +93,12 @@
                             <colordiffuse>FFFFFFFF</colordiffuse>
                             <texturefocus>special://skin/media/buttons/tr_play_fo.png</texturefocus>
                             <texturenofocus>special://skin/media/buttons/tr_play_nofo.png</texturenofocus>
+							<!-- Next Up episode - always play directly -->
+							<onclick condition="String.IsEqual(ListItem.Property(IsNextUpEpisode),true)">Dialog.Close(1107)</onclick>
+							<onclick condition="String.IsEqual(ListItem.Property(IsNextUpEpisode),true)">Dialog.Close(1108)</onclick>
+							<onclick condition="String.IsEqual(ListItem.Property(IsNextUpEpisode),true)">Dialog.Close(movieinformation)</onclick>
+							<onclick condition="String.IsEqual(ListItem.Property(IsNextUpEpisode),true)">ActivateWindow(Videos,plugin://plugin.video.aiostreams/?action=play&amp;content_type=series&amp;imdb_id=$INFO[ListItem.Property(NextUpShowIMDb)]&amp;season=$INFO[ListItem.Property(NextUpSeason)]&amp;episode=$INFO[ListItem.Property(NextUpEpisode)],return)</onclick>
+							<!-- Regular series - browse seasons -->
 							<onclick condition="String.IsEqual(ListItem.Property(content_type),series) | String.IsEqual(ListItem.DBType,tvshow) | String.IsEqual(ListItem.DBType,series)">Dialog.Close(1107)</onclick>
 							<onclick condition="String.IsEqual(ListItem.Property(content_type),series) | String.IsEqual(ListItem.DBType,tvshow) | String.IsEqual(ListItem.DBType,series)">Dialog.Close(1108)</onclick>
 							<onclick condition="String.IsEqual(ListItem.Property(content_type),series) | String.IsEqual(ListItem.DBType,tvshow) | String.IsEqual(ListItem.DBType,series)">Dialog.Close(movieinformation)</onclick>
@@ -112,6 +118,7 @@
                             <top>74</top>
                             <width>258</width>
                             <height>64</height>
+                            <visible>!String.IsEqual(ListItem.Property(IsNextUpEpisode),true)</visible>
                             <!-- Dynamic background images -->
                             <control type="image">
                                 <width>258</width>
@@ -164,6 +171,7 @@
                             <top>74</top>
                             <width>258</width>
                             <height>64</height>
+                            <visible>!String.IsEqual(ListItem.Property(IsNextUpEpisode),true)</visible>
                             <!-- Dynamic background images -->
                             <control type="image">
                                 <width>258</width>

--- a/skin.AIODI/xml/Variables.xml
+++ b/skin.AIODI/xml/Variables.xml
@@ -1450,12 +1450,7 @@
     </variable>
 
     <variable name="PlayButtonLabelVar">
-        <value condition="String.IsEqual(ListItem.DBType,episode) | String.IsEqual(ListItem.DBType,movie)">Play</value>
-        <value>Browse</value>
-    </variable>
-
-    <variable name="PlayButtonLabelVar">
-        <value condition="String.IsEqual(ListItem.DBType,episode) | String.IsEqual(ListItem.DBType,movie)">Play</value>
+        <value condition="String.IsEqual(ListItem.Property(IsNextUpEpisode),true) | String.IsEqual(ListItem.DBType,episode) | String.IsEqual(ListItem.DBType,movie)">Play</value>
         <value>Browse</value>
     </variable>
 


### PR DESCRIPTION
…le direct playback

This commit customizes the information panel (DialogVideoInfo) behavior for Trakt Next Up episodes to provide a streamlined playback experience.

Changes:

1. **Added Next Up identification properties (addon.py)**
   - Set IsNextUpEpisode='true' on Next Up list items
   - Store NextUpShowIMDb, NextUpSeason, NextUpEpisode for direct playback
   - Allows XML to distinguish Next Up episodes from regular items

2. **Hidden watchlist and watched buttons (DialogVideoInfo.xml)**
   - Added visibility condition to hide watchlist button for Next Up episodes
   - Added visibility condition to hide watched button for Next Up episodes
   - These actions don't make sense for "next episode to watch" context

3. **Changed browse/play button to direct playback (DialogVideoInfo.xml)**
   - Added onclick handler to play episode directly when IsNextUpEpisode=true
   - Uses stored properties (NextUpShowIMDb, NextUpSeason, NextUpEpisode)
   - Bypasses season browsing - goes straight to playback
   - Button now says "Play" instead of "Browse" for Next Up items

4. **Updated button label variable (Variables.xml)**
   - Modified PlayButtonLabelVar to show "Play" for Next Up episodes
   - Also removed duplicate variable definition
   - Ensures consistent "Play" label for Next Up items

Result:
- Next Up info panel now shows only relevant buttons (Trailer, Play)
- Play button directly starts episode playback with correct episode ID
- Cleaner, more focused interface for "what to watch next" use case