### PR TITLE
Scale fanart to widget row with aspect ratio, reposition gradients

### DIFF
--- a/skin.AIODI/xml/Home.xml
+++ b/skin.AIODI/xml/Home.xml
@@ -42,35 +42,34 @@
 			<texture>colors/black.png</texture>
 			<aspectratio>scale</aspectratio>
 		</control>
-		<!-- Background Fanart - 50% size anchored to top right -->
+		<!-- Background Fanart - scaled to widget row, aspect ratio maintained, anchored to top right -->
 		<control type="image">
 			<depth>DepthBackground</depth>
 			<right>0</right>
 			<top>0</top>
-			<width>50%</width>
-			<height>50%</height>
+			<bottom>520</bottom>
 			<texture background="true">$VAR[CurrentWidgetFanart]</texture>
-			<aspectratio>scale</aspectratio>
+			<aspectratio>keep</aspectratio>
 		</control>
 
-		<!-- Fanart Left Edge Gradient (fade into black background) -->
+		<!-- Fanart Left Edge Gradient: black (left) to transparent (right), 200px wide, aligned with fanart left edge -->
 		<control type="image">
 			<depth>DepthBackground</depth>
-			<left>50%</left>
+			<left>42%</left>
 			<top>0</top>
 			<width>200</width>
-			<height>50%</height>
+			<bottom>520</bottom>
 			<texture>colors/gradient_left_to_right.png</texture>
 			<aspectratio>stretch</aspectratio>
 		</control>
 
-		<!-- Fanart Bottom Edge Gradient (fade into black background) -->
+		<!-- Fanart Bottom Edge Gradient: black (bottom) to transparent (top), 150px tall, aligned with fanart bottom edge -->
 		<control type="image">
 			<depth>DepthBackground</depth>
 			<right>0</right>
-			<top>50%</top>
-			<width>50%</width>
-			<height>200</height>
+			<bottom>520</bottom>
+			<width>58%</width>
+			<height>150</height>
 			<texture>colors/gradient_top_to_bottom.png</texture>
 			<aspectratio>stretch</aspectratio>
 		</control>


### PR DESCRIPTION
This commit scales the fanart to reach the top of the widget row while maintaining aspect ratio, and repositions the gradients to properly align with the fanart edges.

Changes made:

1. **Scaled fanart to widget row**
   - Changed from fixed 50% width/height to top: 0, bottom: 520
   - Widget row starts at 560px from top (1080 - 520 = 560)
   - Removed width/height specifications to allow auto-calculation
   - Changed aspectratio from "scale" to "keep" to maintain aspect ratio
   - Fanart now expands left while maintaining aspect ratio
   - Anchored to right: 0 and top: 0 as before

2. **Repositioned left edge gradient**
   - Changed from left: 50% to left: 42%
   - Aligns with typical 16:9 fanart left edge (~809px from left = ~42%)
   - Kept width: 200px as requested
   - Changed height from 50% to bottom: 520 to match fanart height
   - Gradient properly fades from black (left) to transparent (right)

3. **Repositioned bottom edge gradient**
   - Kept right: 0 alignment
   - Changed from top: 50% to bottom: 520 to align with fanart bottom edge
   - Reduced height from 200px to 150px as requested
   - Changed width from 50% to 58% to better cover fanart width
   - Gradient properly fades from black (bottom) to transparent (top)

Result:
- Fanart scales to full height from top to widget row
- Maintains aspect ratio and expands left
- Left gradient (200px) fades from black to transparent, aligned with fanart left edge
- Bottom gradient (150px) fades from black to transparent, aligned with fanart bottom edge
- Both gradients properly sized and positioned relative to scaled fanart