### PR TITLE
Fix fanart positioning - anchor to top right properly

### DIFF
--- a/skin.AIODI/xml/Home.xml
+++ b/skin.AIODI/xml/Home.xml
@@ -45,17 +45,18 @@
 		<!-- Background Fanart - scaled to widget row, aspect ratio maintained, anchored to top right -->
 		<control type="image">
 			<depth>DepthBackground</depth>
+			<left>48%</left>
 			<right>0</right>
 			<top>0</top>
 			<bottom>520</bottom>
 			<texture background="true">$VAR[CurrentWidgetFanart]</texture>
-			<aspectratio>keep</aspectratio>
+			<aspectratio align="right" aligny="top">keep</aspectratio>
 		</control>
 
 		<!-- Fanart Left Edge Gradient: black (left) to transparent (right), 200px wide, aligned with fanart left edge -->
 		<control type="image">
 			<depth>DepthBackground</depth>
-			<left>42%</left>
+			<left>48%</left>
 			<top>0</top>
 			<width>200</width>
 			<bottom>520</bottom>
@@ -68,7 +69,7 @@
 			<depth>DepthBackground</depth>
 			<right>0</right>
 			<bottom>520</bottom>
-			<width>58%</width>
+			<width>52%</width>
 			<height>150</height>
 			<texture>colors/gradient_top_to_bottom.png</texture>
 			<aspectratio>stretch</aspectratio>


### PR DESCRIPTION
This commit fixes the fanart positioning to ensure it's properly anchored to the top right corner instead of appearing centered and full width.

Changes made:

1. **Added left boundary for fanart**
   - Added left: 48% to create proper bounding box
   - Fanart now spans from 48% to 100% (52% of screen width)
   - Calculated for typical 16:9 fanart: 560px height × 16/9 = 995px ≈ 52% width

2. **Added explicit alignment**
   - Changed aspectratio from "keep" to 'align="right" aligny="top"'
   - Ensures fanart is anchored to top right corner of bounding box
   - Prevents centering behavior

3. **Updated left gradient position**
   - Changed from left: 42% to left: 48%
   - Now aligns with actual fanart left edge
   - 200px gradient properly covers fanart's left edge

4. **Updated bottom gradient width**
   - Changed from 58% to 52%
   - Matches fanart's actual width
   - Ensures gradient covers full fanart width

Result:
- Fanart is now properly anchored to top right
- Maintains aspect ratio and expands left from right edge
- Gradients properly aligned with fanart edges
- No more center alignment or full width issues