### PR TITLE
Fix info window property cleanup and rating display visibility

### DIFF
--- a/skin.AIODI/resources/lib/info_window_helper.py
+++ b/skin.AIODI/resources/lib/info_window_helper.py
@@ -175,17 +175,35 @@ def populate_cast_properties(content_type=None):
 
 
 def reset_info_properties():
-    """Resets all info window properties to trigger loading state."""
+    """Resets all info window properties to trigger loading state and clear previous data."""
     win = xbmcgui.Window(10000)
     win.setProperty('AsyncLoading', 'true')
-    
+
     # Clear Metadata
     win.clearProperty('InfoWindow.Director')
     win.clearProperty('InfoWindow.Rating')
     win.clearProperty('InfoWindow.Premiered')
     win.clearProperty('InfoWindow.Duration')
-    
-    xbmc.log('[info_window_helper] Properties reset. AsyncLoading=true', xbmc.LOGINFO)
+    win.clearProperty('InfoWindow.Trailer')
+
+    # Clear Cast properties (1-5)
+    for i in range(1, 6):
+        win.clearProperty(f'InfoWindow.Cast.{i}.Name')
+        win.clearProperty(f'InfoWindow.Cast.{i}.Role')
+        win.clearProperty(f'InfoWindow.Cast.{i}.Thumb')
+
+    # Clear Related Content properties (1-10)
+    for i in range(1, 11):
+        win.clearProperty(f'InfoWindow.Related.{i}.Title')
+        win.clearProperty(f'InfoWindow.Related.{i}.Thumb')
+        win.clearProperty(f'InfoWindow.Related.{i}.Year')
+        win.clearProperty(f'InfoWindow.Related.{i}.IMDB')
+
+    # Clear Trakt status properties
+    win.clearProperty('InfoWindow.IsWatchlist')
+    win.clearProperty('InfoWindow.IsWatched')
+
+    xbmc.log('[info_window_helper] All properties reset. AsyncLoading=true', xbmc.LOGINFO)
 
 def populate_all():
     """Populates all info window data asynchronously."""

--- a/skin.AIODI/xml/DialogVideoInfo.xml
+++ b/skin.AIODI/xml/DialogVideoInfo.xml
@@ -591,6 +591,7 @@
 							<control type="group">
 								<width>200</width>
 								<height>40</height>
+								<visible>!String.IsEmpty($VAR[InfoWindow_Rating])</visible>
 								<control type="button" id="8005">
 									<left>0</left>
 									<top>0</top>
@@ -619,7 +620,7 @@
 								<height>30</height>
 								<texture>imdb_logo.png</texture>
 								<aspectratio>keep</aspectratio>
-								<visible>true</visible>
+								<visible>!String.IsEmpty($VAR[InfoWindow_Rating])</visible>
 							</control>
 						</control>
 					</control>

--- a/skin.AIODI/xml/Home.xml
+++ b/skin.AIODI/xml/Home.xml
@@ -228,6 +228,7 @@
 						<top>0</top>
 						<width>150</width>
 						<height>40</height>
+						<visible>!String.IsEmpty($VAR[ActiveItem_IMDbRating])</visible>
 
 						<control type="button" id="9905">
 							<left>0</left>
@@ -337,7 +338,7 @@
 					<top>0</top>
 					<width>150</width>
 					<height>40</height>
-					<visible>true</visible>
+					<visible>!String.IsEmpty($VAR[ActiveItem_IMDbRating])</visible>
 
 					<control type="button" id="9914">
 						<left>0</left>
@@ -367,6 +368,7 @@
 						<height>30</height>
 						<texture>imdb_logo.png</texture>
 						<aspectratio>keep</aspectratio>
+						<visible>!String.IsEmpty($VAR[ActiveItem_IMDbRating])</visible>
 					</control>
 				</control>
 			</control>


### PR DESCRIPTION
## Summary
This PR improves the info window property management and fixes rating display visibility issues in the AIODI skin. It ensures that all dynamic properties are properly cleared between content loads and only displays rating elements when data is actually available.

## Key Changes

- **Enhanced property reset function**: Extended `reset_info_properties()` to comprehensively clear all dynamic properties including:
  - Trailer property
  - Cast properties (5 cast members with name, role, and thumbnail)
  - Related content properties (10 items with title, thumbnail, year, and IMDB ID)
  - Trakt status properties (watchlist and watched flags)

- **Fixed rating display visibility**: Updated visibility conditions in both `DialogVideoInfo.xml` and `Home.xml` to conditionally show rating elements only when rating data is available:
  - Changed hardcoded `<visible>true</visible>` to `<visible>!String.IsEmpty($VAR[InfoWindow_Rating])</visible>` in DialogVideoInfo
  - Changed hardcoded `<visible>true</visible>` to `<visible>!String.IsEmpty($VAR[ActiveItem_IMDbRating])</visible>` in Home
  - Applied visibility condition to IMDB logo in Home.xml

- **Code cleanup**: Fixed trailing whitespace in Python file

## Implementation Details
The property reset function now uses loops to efficiently clear indexed properties (cast members 1-5 and related content 1-10) rather than individual clearProperty calls, making the code more maintainable and scalable. The visibility fixes prevent empty rating UI elements from appearing when no rating data has been loaded yet.

https://claude.ai/code/session_01TEQeZb4iSRKUTTdbQo1Pcy