### PR TITLE
Add detailed logging and fix IMDb rating visibility conditions

### DIFF
--- a/skin.AIODI/resources/lib/fetch_cast.py
+++ b/skin.AIODI/resources/lib/fetch_cast.py
@@ -44,6 +44,15 @@ def fetch_cast_from_api(imdb_id, content_type='movie'):
         meta = data.get('meta', {})
         app_extras = meta.get('app_extras', {})
         cast_list = app_extras.get('cast', [])
+
+        # Debug: Log the raw cast data structure
+        log(f'API returned {len(cast_list)} cast members')
+        if cast_list:
+            for idx, cast_member in enumerate(cast_list[:3]):  # Log first 3 for debugging
+                log(f'Cast {idx+1} data: {cast_member}')
+                log(f'  - name: {cast_member.get("name", "MISSING")}')
+                log(f'  - character: {cast_member.get("character", "MISSING")}')
+                log(f'  - photo: {cast_member.get("photo", "MISSING")}')
         
         # Extract Trailer
         trailers = []

--- a/skin.AIODI/resources/lib/info_window_helper.py
+++ b/skin.AIODI/resources/lib/info_window_helper.py
@@ -132,7 +132,7 @@ def populate_cast_properties(content_type=None):
                         home_window.setProperty(f'InfoWindow.Cast.{i}.Name', name)
                         home_window.setProperty(f'InfoWindow.Cast.{i}.Role', role)
                         home_window.setProperty(f'InfoWindow.Cast.{i}.Thumb', thumb)
-                        log(f'Set cast {i}: {name}')
+                        log(f'Set cast {i}: Name="{name}", Role="{role}", Thumb="{thumb}"')
             
             # SET ADDITIONAL METADATA PROPERTIES
             director = meta_data.get('director', '')

--- a/skin.AIODI/xml/DialogVideoInfo.xml
+++ b/skin.AIODI/xml/DialogVideoInfo.xml
@@ -591,7 +591,7 @@
 							<control type="group">
 								<width>200</width>
 								<height>40</height>
-								<visible>!String.IsEmpty($VAR[InfoWindow_Rating])</visible>
+								<visible>!String.IsEmpty(Window(Home).Property(InfoWindow.Rating)) | !String.IsEmpty(ListItem.Property(IMDbRating)) | !String.IsEmpty(ListItem.Rating)</visible>
 								<control type="button" id="8005">
 									<left>0</left>
 									<top>0</top>
@@ -620,7 +620,7 @@
 								<height>30</height>
 								<texture>imdb_logo.png</texture>
 								<aspectratio>keep</aspectratio>
-								<visible>!String.IsEmpty($VAR[InfoWindow_Rating])</visible>
+								<visible>!String.IsEmpty(Window(Home).Property(InfoWindow.Rating)) | !String.IsEmpty(ListItem.Property(IMDbRating)) | !String.IsEmpty(ListItem.Rating)</visible>
 							</control>
 						</control>
 					</control>


### PR DESCRIPTION
- Added comprehensive logging to fetch_cast.py to debug cast photo URLs
  - Logs first 3 cast members with name, character, and photo fields
  - Helps identify if API returns photo URLs or if they're missing

- Enhanced logging in info_window_helper.py to show all cast property values
  - Logs Name, Role, AND Thumb URL for each cast member set
  - Makes it easy to see in logs if thumb URLs are empty or invalid

- Fixed IMDb rating visibility condition in DialogVideoInfo.xml
  - Changed from checking variable (which has fallbacks) to checking specific properties
  - Now checks: Window(Home).Property(InfoWindow.Rating) OR ListItem.Property(IMDbRating) OR ListItem.Rating
  - Prevents rating chip from being hidden when rating IS available
  - Applied to both rating group and IMDb logo

These changes provide detailed debugging info to diagnose cast image loading issues and fix the rating visibility problem.

https://claude.ai/code/session_01TEQeZb4iSRKUTTdbQo1Pcy