### PR TITLE
Fix cast tile images not loading by adding background='true' attribute

### DIFF
--- a/skin.AIODI/xml/DialogVideoInfo.xml
+++ b/skin.AIODI/xml/DialogVideoInfo.xml
@@ -361,8 +361,8 @@
 							<top>150</top>
 							<width>180</width>
 							<height>270</height>
-							<texturenofocus>$INFO[Window(Home).Property(InfoWindow.Cast.1.Thumb)]</texturenofocus>
-							<texturefocus border="3" colordiffuse="FFFF0000">$INFO[Window(Home).Property(InfoWindow.Cast.1.Thumb)]</texturefocus>
+							<texturenofocus background="true">$INFO[Window(Home).Property(InfoWindow.Cast.1.Thumb)]</texturenofocus>
+							<texturefocus background="true" border="3" colordiffuse="FFFF0000">$INFO[Window(Home).Property(InfoWindow.Cast.1.Thumb)]</texturefocus>
 							<aspectratio aligny="center">scale</aspectratio>
 							<label>$INFO[Window(Home).Property(InfoWindow.Cast.1.Name)]</label>
 							<font>font12</font>
@@ -385,8 +385,8 @@
 							<top>150</top>
 							<width>180</width>
 							<height>270</height>
-							<texturenofocus>$INFO[Window(Home).Property(InfoWindow.Cast.2.Thumb)]</texturenofocus>
-							<texturefocus border="3" colordiffuse="FFFF0000">$INFO[Window(Home).Property(InfoWindow.Cast.2.Thumb)]</texturefocus>
+							<texturenofocus background="true">$INFO[Window(Home).Property(InfoWindow.Cast.2.Thumb)]</texturenofocus>
+							<texturefocus background="true" border="3" colordiffuse="FFFF0000">$INFO[Window(Home).Property(InfoWindow.Cast.2.Thumb)]</texturefocus>
 							<aspectratio aligny="center">scale</aspectratio>
 							<label>$INFO[Window(Home).Property(InfoWindow.Cast.2.Name)]</label>
 							<font>font12</font>
@@ -409,8 +409,8 @@
 							<top>150</top>
 							<width>180</width>
 							<height>270</height>
-							<texturenofocus>$INFO[Window(Home).Property(InfoWindow.Cast.3.Thumb)]</texturenofocus>
-							<texturefocus border="3" colordiffuse="FFFF0000">$INFO[Window(Home).Property(InfoWindow.Cast.3.Thumb)]</texturefocus>
+							<texturenofocus background="true">$INFO[Window(Home).Property(InfoWindow.Cast.3.Thumb)]</texturenofocus>
+							<texturefocus background="true" border="3" colordiffuse="FFFF0000">$INFO[Window(Home).Property(InfoWindow.Cast.3.Thumb)]</texturefocus>
 							<aspectratio aligny="center">scale</aspectratio>
 							<label>$INFO[Window(Home).Property(InfoWindow.Cast.3.Name)]</label>
 							<font>font12</font>
@@ -433,8 +433,8 @@
 							<top>150</top>
 							<width>180</width>
 							<height>270</height>
-							<texturenofocus>$INFO[Window(Home).Property(InfoWindow.Cast.4.Thumb)]</texturenofocus>
-							<texturefocus border="3" colordiffuse="FFFF0000">$INFO[Window(Home).Property(InfoWindow.Cast.4.Thumb)]</texturefocus>
+							<texturenofocus background="true">$INFO[Window(Home).Property(InfoWindow.Cast.4.Thumb)]</texturenofocus>
+							<texturefocus background="true" border="3" colordiffuse="FFFF0000">$INFO[Window(Home).Property(InfoWindow.Cast.4.Thumb)]</texturefocus>
 							<aspectratio aligny="center">scale</aspectratio>
 							<label>$INFO[Window(Home).Property(InfoWindow.Cast.4.Name)]</label>
 							<font>font12</font>
@@ -457,8 +457,8 @@
 							<top>150</top>
 							<width>180</width>
 							<height>270</height>
-							<texturenofocus>$INFO[Window(Home).Property(InfoWindow.Cast.5.Thumb)]</texturenofocus>
-							<texturefocus border="3" colordiffuse="FFFF0000">$INFO[Window(Home).Property(InfoWindow.Cast.5.Thumb)]</texturefocus>
+							<texturenofocus background="true">$INFO[Window(Home).Property(InfoWindow.Cast.5.Thumb)]</texturenofocus>
+							<texturefocus background="true" border="3" colordiffuse="FFFF0000">$INFO[Window(Home).Property(InfoWindow.Cast.5.Thumb)]</texturefocus>
 							<aspectratio aligny="center">scale</aspectratio>
 			<label>$INFO[Window(Home).Property(InfoWindow.Cast.5.Name)]</label>
 							<font>font12</font>


### PR DESCRIPTION
The issue was that cast tiles used button controls with texturenofocus/texturefocus but were missing the background="true" attribute needed to load images asynchronously from URLs.

Related Content section works correctly because it uses:
  <texture background="true">$INFO[ListItem.Thumb]</texture>

Cast tiles were using:
  <texturenofocus>$INFO[Window(Home).Property(InfoWindow.Cast.1.Thumb)]</texturenofocus>

Fixed all 5 cast tiles by adding background="true" to both texturenofocus and texturefocus elements:
  <texturenofocus background="true">$INFO[...]</texturenofocus>
  <texturefocus background="true" border="3" colordiffuse="FFFF0000">$INFO[...]</texturefocus>

This enables async loading of cast photos from TMDB image URLs.

https://claude.ai/code/session_01TEQeZb4iSRKUTTdbQo1Pcy