### PR TITLE
Restructure cast tiles to use image controls instead of button textures

### DIFF
--- a/skin.AIODI/xml/DialogVideoInfo.xml
+++ b/skin.AIODI/xml/DialogVideoInfo.xml
@@ -356,123 +356,263 @@
 						<height>310</height>
 
 						<!-- Cast Tile 1 -->
-						<control type="button">
+						<control type="group">
 							<left>0</left>
 							<top>150</top>
 							<width>180</width>
 							<height>270</height>
-							<texturenofocus background="true">$INFO[Window(Home).Property(InfoWindow.Cast.1.Thumb)]</texturenofocus>
-							<texturefocus background="true" border="3" colordiffuse="FFFF0000">$INFO[Window(Home).Property(InfoWindow.Cast.1.Thumb)]</texturefocus>
-							<aspectratio aligny="center">scale</aspectratio>
-							<label>$INFO[Window(Home).Property(InfoWindow.Cast.1.Name)]</label>
-							<font>font12</font>
-							<textcolor>white</textcolor>
-							<textoffsetx>0</textoffsetx>
-							<textoffsety>220</textoffsety>
-							<align>center</align>
-							<onclick>Dialog.Close(MovieInformation)</onclick>
-							<onclick>RunScript(special://skin/resources/lib/global_search.py, $INFO[Window(Home).Property(InfoWindow.Cast.1.Name)])</onclick>
 							<visible>!String.IsEmpty(Window(Home).Property(InfoWindow.Cast.1.Name))</visible>
-							<onup>8000</onup>
-							<onleft>8</onleft>
-							<onright>50</onright>
-							<ondown>5000</ondown>
+							<!-- Background image -->
+							<control type="image">
+								<left>0</left>
+								<top>0</top>
+								<width>180</width>
+								<height>270</height>
+								<aspectratio aligny="center">scale</aspectratio>
+								<texture background="true">$INFO[Window(Home).Property(InfoWindow.Cast.1.Thumb)]</texture>
+							</control>
+							<!-- Name label overlay -->
+							<control type="image">
+								<left>0</left>
+								<top>220</top>
+								<width>180</width>
+								<height>50</height>
+								<texture>colors/black_50.png</texture>
+							</control>
+							<control type="label">
+								<left>0</left>
+								<top>220</top>
+								<width>180</width>
+								<height>50</height>
+								<align>center</align>
+								<aligny>center</aligny>
+								<font>font12</font>
+								<textcolor>white</textcolor>
+								<label>$INFO[Window(Home).Property(InfoWindow.Cast.1.Name)]</label>
+							</control>
+							<!-- Clickable button overlay -->
+							<control type="button">
+								<left>0</left>
+								<top>0</top>
+								<width>180</width>
+								<height>270</height>
+								<texturenofocus>-</texturenofocus>
+								<texturefocus border="3" colordiffuse="FFFF0000">colors/white.png</texturefocus>
+								<onclick>Dialog.Close(MovieInformation)</onclick>
+								<onclick>RunScript(special://skin/resources/lib/global_search.py, $INFO[Window(Home).Property(InfoWindow.Cast.1.Name)])</onclick>
+								<onup>8000</onup>
+								<onleft>8</onleft>
+								<onright>50</onright>
+								<ondown>5000</ondown>
+							</control>
 						</control>
 
 						<!-- Cast Tile 2 -->
-						<control type="button">
+						<control type="group">
 							<left>204</left>
 							<top>150</top>
 							<width>180</width>
 							<height>270</height>
-							<texturenofocus background="true">$INFO[Window(Home).Property(InfoWindow.Cast.2.Thumb)]</texturenofocus>
-							<texturefocus background="true" border="3" colordiffuse="FFFF0000">$INFO[Window(Home).Property(InfoWindow.Cast.2.Thumb)]</texturefocus>
-							<aspectratio aligny="center">scale</aspectratio>
-							<label>$INFO[Window(Home).Property(InfoWindow.Cast.2.Name)]</label>
-							<font>font12</font>
-							<textcolor>white</textcolor>
-							<textoffsetx>0</textoffsetx>
-							<textoffsety>220</textoffsety>
-							<align>center</align>
-							<onclick>Dialog.Close(MovieInformation)</onclick>
-							<onclick>RunScript(special://skin/resources/lib/global_search.py, $INFO[Window(Home).Property(InfoWindow.Cast.2.Name)])</onclick>
 							<visible>!String.IsEmpty(Window(Home).Property(InfoWindow.Cast.2.Name))</visible>
-							<onup>8000</onup>
-							<onleft>50</onleft>
-							<onright>50</onright>
-							<ondown>5000</ondown>
+							<!-- Background image -->
+							<control type="image">
+								<left>0</left>
+								<top>0</top>
+								<width>180</width>
+								<height>270</height>
+								<aspectratio aligny="center">scale</aspectratio>
+								<texture background="true">$INFO[Window(Home).Property(InfoWindow.Cast.2.Thumb)]</texture>
+							</control>
+							<!-- Name label overlay -->
+							<control type="image">
+								<left>0</left>
+								<top>220</top>
+								<width>180</width>
+								<height>50</height>
+								<texture>colors/black_50.png</texture>
+							</control>
+							<control type="label">
+								<left>0</left>
+								<top>220</top>
+								<width>180</width>
+								<height>50</height>
+								<align>center</align>
+								<aligny>center</aligny>
+								<font>font12</font>
+								<textcolor>white</textcolor>
+								<label>$INFO[Window(Home).Property(InfoWindow.Cast.2.Name)]</label>
+							</control>
+							<!-- Clickable button overlay -->
+							<control type="button">
+								<left>0</left>
+								<top>0</top>
+								<width>180</width>
+								<height>270</height>
+								<texturenofocus>-</texturenofocus>
+								<texturefocus border="3" colordiffuse="FFFF0000">colors/white.png</texturefocus>
+								<onclick>Dialog.Close(MovieInformation)</onclick>
+								<onclick>RunScript(special://skin/resources/lib/global_search.py, $INFO[Window(Home).Property(InfoWindow.Cast.2.Name)])</onclick>
+								<onup>8000</onup>
+								<onleft>50</onleft>
+								<onright>50</onright>
+								<ondown>5000</ondown>
+							</control>
 						</control>
 
 						<!-- Cast Tile 3 -->
-						<control type="button">
+						<control type="group">
 							<left>408</left>
 							<top>150</top>
 							<width>180</width>
 							<height>270</height>
-							<texturenofocus background="true">$INFO[Window(Home).Property(InfoWindow.Cast.3.Thumb)]</texturenofocus>
-							<texturefocus background="true" border="3" colordiffuse="FFFF0000">$INFO[Window(Home).Property(InfoWindow.Cast.3.Thumb)]</texturefocus>
-							<aspectratio aligny="center">scale</aspectratio>
-							<label>$INFO[Window(Home).Property(InfoWindow.Cast.3.Name)]</label>
-							<font>font12</font>
-							<textcolor>white</textcolor>
-							<textoffsetx>0</textoffsetx>
-							<textoffsety>220</textoffsety>
-							<align>center</align>
-							<onclick>Dialog.Close(MovieInformation)</onclick>
-							<onclick>RunScript(special://skin/resources/lib/global_search.py, $INFO[Window(Home).Property(InfoWindow.Cast.3.Name)])</onclick>
 							<visible>!String.IsEmpty(Window(Home).Property(InfoWindow.Cast.3.Name))</visible>
-							<onup>8000</onup>
-							<onleft>50</onleft>
-							<onright>50</onright>
-							<ondown>5000</ondown>
+							<!-- Background image -->
+							<control type="image">
+								<left>0</left>
+								<top>0</top>
+								<width>180</width>
+								<height>270</height>
+								<aspectratio aligny="center">scale</aspectratio>
+								<texture background="true">$INFO[Window(Home).Property(InfoWindow.Cast.3.Thumb)]</texture>
+							</control>
+							<!-- Name label overlay -->
+							<control type="image">
+								<left>0</left>
+								<top>220</top>
+								<width>180</width>
+								<height>50</height>
+								<texture>colors/black_50.png</texture>
+							</control>
+							<control type="label">
+								<left>0</left>
+								<top>220</top>
+								<width>180</width>
+								<height>50</height>
+								<align>center</align>
+								<aligny>center</aligny>
+								<font>font12</font>
+								<textcolor>white</textcolor>
+								<label>$INFO[Window(Home).Property(InfoWindow.Cast.3.Name)]</label>
+							</control>
+							<!-- Clickable button overlay -->
+							<control type="button">
+								<left>0</left>
+								<top>0</top>
+								<width>180</width>
+								<height>270</height>
+								<texturenofocus>-</texturenofocus>
+								<texturefocus border="3" colordiffuse="FFFF0000">colors/white.png</texturefocus>
+								<onclick>Dialog.Close(MovieInformation)</onclick>
+								<onclick>RunScript(special://skin/resources/lib/global_search.py, $INFO[Window(Home).Property(InfoWindow.Cast.3.Name)])</onclick>
+								<onup>8000</onup>
+								<onleft>50</onleft>
+								<onright>50</onright>
+								<ondown>5000</ondown>
+							</control>
 						</control>
 
 						<!-- Cast Tile 4 -->
-						<control type="button">
+						<control type="group">
 							<left>612</left>
 							<top>150</top>
 							<width>180</width>
 							<height>270</height>
-							<texturenofocus background="true">$INFO[Window(Home).Property(InfoWindow.Cast.4.Thumb)]</texturenofocus>
-							<texturefocus background="true" border="3" colordiffuse="FFFF0000">$INFO[Window(Home).Property(InfoWindow.Cast.4.Thumb)]</texturefocus>
-							<aspectratio aligny="center">scale</aspectratio>
-							<label>$INFO[Window(Home).Property(InfoWindow.Cast.4.Name)]</label>
-							<font>font12</font>
-							<textcolor>white</textcolor>
-							<textoffsetx>0</textoffsetx>
-							<textoffsety>220</textoffsety>
-							<align>center</align>
-							<onclick>Dialog.Close(MovieInformation)</onclick>
-							<onclick>RunScript(special://skin/resources/lib/global_search.py, $INFO[Window(Home).Property(InfoWindow.Cast.4.Name)])</onclick>
 							<visible>!String.IsEmpty(Window(Home).Property(InfoWindow.Cast.4.Name))</visible>
-							<onup>8000</onup>
-							<onleft>50</onleft>
-							<onright>50</onright>
-							<ondown>5000</ondown>
+							<!-- Background image -->
+							<control type="image">
+								<left>0</left>
+								<top>0</top>
+								<width>180</width>
+								<height>270</height>
+								<aspectratio aligny="center">scale</aspectratio>
+								<texture background="true">$INFO[Window(Home).Property(InfoWindow.Cast.4.Thumb)]</texture>
+							</control>
+							<!-- Name label overlay -->
+							<control type="image">
+								<left>0</left>
+								<top>220</top>
+								<width>180</width>
+								<height>50</height>
+								<texture>colors/black_50.png</texture>
+							</control>
+							<control type="label">
+								<left>0</left>
+								<top>220</top>
+								<width>180</width>
+								<height>50</height>
+								<align>center</align>
+								<aligny>center</aligny>
+								<font>font12</font>
+								<textcolor>white</textcolor>
+								<label>$INFO[Window(Home).Property(InfoWindow.Cast.4.Name)]</label>
+							</control>
+							<!-- Clickable button overlay -->
+							<control type="button">
+								<left>0</left>
+								<top>0</top>
+								<width>180</width>
+								<height>270</height>
+								<texturenofocus>-</texturenofocus>
+								<texturefocus border="3" colordiffuse="FFFF0000">colors/white.png</texturefocus>
+								<onclick>Dialog.Close(MovieInformation)</onclick>
+								<onclick>RunScript(special://skin/resources/lib/global_search.py, $INFO[Window(Home).Property(InfoWindow.Cast.4.Name)])</onclick>
+								<onup>8000</onup>
+								<onleft>50</onleft>
+								<onright>50</onright>
+								<ondown>5000</ondown>
+							</control>
 						</control>
 
 						<!-- Cast Tile 5 -->
-						<control type="button">
+						<control type="group">
 							<left>816</left>
 							<top>150</top>
 							<width>180</width>
 							<height>270</height>
-							<texturenofocus background="true">$INFO[Window(Home).Property(InfoWindow.Cast.5.Thumb)]</texturenofocus>
-							<texturefocus background="true" border="3" colordiffuse="FFFF0000">$INFO[Window(Home).Property(InfoWindow.Cast.5.Thumb)]</texturefocus>
-							<aspectratio aligny="center">scale</aspectratio>
-			<label>$INFO[Window(Home).Property(InfoWindow.Cast.5.Name)]</label>
-							<font>font12</font>
-							<textcolor>white</textcolor>
-							<textoffsetx>0</textoffsetx>
-							<textoffsety>220</textoffsety>
-							<align>center</align>
-							<onclick>Dialog.Close(MovieInformation)</onclick>
-							<onclick>RunScript(special://skin/resources/lib/global_search.py, $INFO[Window(Home).Property(InfoWindow.Cast.5.Name)])</onclick>
 							<visible>!String.IsEmpty(Window(Home).Property(InfoWindow.Cast.5.Name))</visible>
-							<onup>8000</onup>
-							<onleft>50</onleft>
-							<onright>8001</onright>
-							<ondown>5000</ondown>
+							<!-- Background image -->
+							<control type="image">
+								<left>0</left>
+								<top>0</top>
+								<width>180</width>
+								<height>270</height>
+								<aspectratio aligny="center">scale</aspectratio>
+								<texture background="true">$INFO[Window(Home).Property(InfoWindow.Cast.5.Thumb)]</texture>
+							</control>
+							<!-- Name label overlay -->
+							<control type="image">
+								<left>0</left>
+								<top>220</top>
+								<width>180</width>
+								<height>50</height>
+								<texture>colors/black_50.png</texture>
+							</control>
+							<control type="label">
+								<left>0</left>
+								<top>220</top>
+								<width>180</width>
+								<height>50</height>
+								<align>center</align>
+								<aligny>center</aligny>
+								<font>font12</font>
+								<textcolor>white</textcolor>
+								<label>$INFO[Window(Home).Property(InfoWindow.Cast.5.Name)]</label>
+							</control>
+							<!-- Clickable button overlay -->
+							<control type="button">
+								<left>0</left>
+								<top>0</top>
+								<width>180</width>
+								<height>270</height>
+								<texturenofocus>-</texturenofocus>
+								<texturefocus border="3" colordiffuse="FFFF0000">colors/white.png</texturefocus>
+								<onclick>Dialog.Close(MovieInformation)</onclick>
+								<onclick>RunScript(special://skin/resources/lib/global_search.py, $INFO[Window(Home).Property(InfoWindow.Cast.5.Name)])</onclick>
+								<onup>8000</onup>
+								<onleft>50</onleft>
+								<onright>8001</onright>
+								<ondown>5000</ondown>
+							</control>
 						</control>
 					</control>
 


### PR DESCRIPTION
Changed all 5 cast tiles from button-based to group-based structure matching the working Related Content section. Each cast tile now contains:

1. <control type="image"> with background="true" for async image loading
   - Loads cast photo from Window(Home).Property(InfoWindow.Cast.X.Thumb)
   - Uses aspectratio="scale" aligny="center" for proper scaling

2. Semi-transparent black overlay at bottom for name label
   - <control type="image"> with colors/black_50.png texture

3. <control type="label"> for cast member name display
   - Centered white text over semi-transparent background

4. <control type="button"> as transparent overlay for interactivity
   - Transparent unfocused state (texturenofocus="-")
   - Red border on focus (texturefocus with FFFF0000 border)
   - Maintains all onclick actions for global_search.py integration
   - Preserves navigation (onup/onleft/onright/ondown)

This matches the pattern used in Related Content section which successfully loads images from URLs. Button textures cannot load remote URLs reliably, but image controls with background="true" can.

https://claude.ai/code/session_01TEQeZb4iSRKUTTdbQo1Pcy