### PR TITLE
Fix cast tile navigation, borders, and date formatting

### DIFF
--- a/skin.AIODI/resources/lib/info_window_helper.py
+++ b/skin.AIODI/resources/lib/info_window_helper.py
@@ -149,10 +149,24 @@ def populate_cast_properties(content_type=None):
                 log(f'Set InfoWindow.Rating: {rating}')
             
             if premiered:
-                # Format: "2008-01-20T12:00:00.000Z" -> "2008-01-20"
-                if 'T' in premiered: premiered = premiered.split('T')[0]
-                home_window.setProperty('InfoWindow.Premiered', premiered)
-                log(f'Set InfoWindow.Premiered: {premiered}')
+                # Format: "2008-01-20T12:00:00.000Z" -> user's date format
+                if 'T' in premiered:
+                    premiered = premiered.split('T')[0]
+
+                # Convert to Kodi's default date format
+                try:
+                    from datetime import datetime
+                    date_obj = datetime.strptime(premiered, '%Y-%m-%d')
+                    # Use Kodi's regional date format
+                    date_format = xbmc.getRegion('dateshort')
+                    # Convert Python strftime format: %d/%m/%Y -> dd/mm/yyyy
+                    formatted_date = date_obj.strftime(date_format)
+                    home_window.setProperty('InfoWindow.Premiered', formatted_date)
+                    log(f'Set InfoWindow.Premiered: {formatted_date}')
+                except Exception as e:
+                    # Fallback to original if formatting fails
+                    home_window.setProperty('InfoWindow.Premiered', premiered)
+                    log(f'Set InfoWindow.Premiered (fallback): {premiered}')
             
             if runtime:
                 # Format: "125 min" or "2h 5m"

--- a/skin.AIODI/xml/DialogVideoInfo.xml
+++ b/skin.AIODI/xml/DialogVideoInfo.xml
@@ -391,18 +391,18 @@
 								<label>$INFO[Window(Home).Property(InfoWindow.Cast.1.Name)]</label>
 							</control>
 							<!-- Clickable button overlay -->
-							<control type="button">
+							<control type="button" id="50001">
 								<left>0</left>
 								<top>0</top>
 								<width>180</width>
 								<height>270</height>
 								<texturenofocus>-</texturenofocus>
-								<texturefocus border="3" colordiffuse="FFFF0000">colors/white.png</texturefocus>
+								<texturefocus border="3">borders/border-focus.png</texturefocus>
 								<onclick>Dialog.Close(MovieInformation)</onclick>
 								<onclick>RunScript(special://skin/resources/lib/global_search.py, $INFO[Window(Home).Property(InfoWindow.Cast.1.Name)])</onclick>
 								<onup>8000</onup>
 								<onleft>8</onleft>
-								<onright>50</onright>
+								<onright>50002</onright>
 								<ondown>5000</ondown>
 							</control>
 						</control>
@@ -443,18 +443,18 @@
 								<label>$INFO[Window(Home).Property(InfoWindow.Cast.2.Name)]</label>
 							</control>
 							<!-- Clickable button overlay -->
-							<control type="button">
+							<control type="button" id="50002">
 								<left>0</left>
 								<top>0</top>
 								<width>180</width>
 								<height>270</height>
 								<texturenofocus>-</texturenofocus>
-								<texturefocus border="3" colordiffuse="FFFF0000">colors/white.png</texturefocus>
+								<texturefocus border="3">borders/border-focus.png</texturefocus>
 								<onclick>Dialog.Close(MovieInformation)</onclick>
 								<onclick>RunScript(special://skin/resources/lib/global_search.py, $INFO[Window(Home).Property(InfoWindow.Cast.2.Name)])</onclick>
 								<onup>8000</onup>
-								<onleft>50</onleft>
-								<onright>50</onright>
+								<onleft>50001</onleft>
+								<onright>50003</onright>
 								<ondown>5000</ondown>
 							</control>
 						</control>
@@ -495,18 +495,18 @@
 								<label>$INFO[Window(Home).Property(InfoWindow.Cast.3.Name)]</label>
 							</control>
 							<!-- Clickable button overlay -->
-							<control type="button">
+							<control type="button" id="50003">
 								<left>0</left>
 								<top>0</top>
 								<width>180</width>
 								<height>270</height>
 								<texturenofocus>-</texturenofocus>
-								<texturefocus border="3" colordiffuse="FFFF0000">colors/white.png</texturefocus>
+								<texturefocus border="3">borders/border-focus.png</texturefocus>
 								<onclick>Dialog.Close(MovieInformation)</onclick>
 								<onclick>RunScript(special://skin/resources/lib/global_search.py, $INFO[Window(Home).Property(InfoWindow.Cast.3.Name)])</onclick>
 								<onup>8000</onup>
-								<onleft>50</onleft>
-								<onright>50</onright>
+								<onleft>50002</onleft>
+								<onright>50004</onright>
 								<ondown>5000</ondown>
 							</control>
 						</control>
@@ -547,18 +547,18 @@
 								<label>$INFO[Window(Home).Property(InfoWindow.Cast.4.Name)]</label>
 							</control>
 							<!-- Clickable button overlay -->
-							<control type="button">
+							<control type="button" id="50004">
 								<left>0</left>
 								<top>0</top>
 								<width>180</width>
 								<height>270</height>
 								<texturenofocus>-</texturenofocus>
-								<texturefocus border="3" colordiffuse="FFFF0000">colors/white.png</texturefocus>
+								<texturefocus border="3">borders/border-focus.png</texturefocus>
 								<onclick>Dialog.Close(MovieInformation)</onclick>
 								<onclick>RunScript(special://skin/resources/lib/global_search.py, $INFO[Window(Home).Property(InfoWindow.Cast.4.Name)])</onclick>
 								<onup>8000</onup>
-								<onleft>50</onleft>
-								<onright>50</onright>
+								<onleft>50003</onleft>
+								<onright>50005</onright>
 								<ondown>5000</ondown>
 							</control>
 						</control>
@@ -599,17 +599,17 @@
 								<label>$INFO[Window(Home).Property(InfoWindow.Cast.5.Name)]</label>
 							</control>
 							<!-- Clickable button overlay -->
-							<control type="button">
+							<control type="button" id="50005">
 								<left>0</left>
 								<top>0</top>
 								<width>180</width>
 								<height>270</height>
 								<texturenofocus>-</texturenofocus>
-								<texturefocus border="3" colordiffuse="FFFF0000">colors/white.png</texturefocus>
+								<texturefocus border="3">borders/border-focus.png</texturefocus>
 								<onclick>Dialog.Close(MovieInformation)</onclick>
 								<onclick>RunScript(special://skin/resources/lib/global_search.py, $INFO[Window(Home).Property(InfoWindow.Cast.5.Name)])</onclick>
 								<onup>8000</onup>
-								<onleft>50</onleft>
+								<onleft>50004</onleft>
 								<onright>8001</onright>
 								<ondown>5000</ondown>
 							</control>


### PR DESCRIPTION
Cast Tile Fixes:
- Added unique button IDs (50001-50005) to all 5 cast tile buttons for proper navigation
- Fixed onright navigation to link cast tiles sequentially (50001->50002->...->50005)
- Fixed onleft navigation to link back through cast tiles
- Changed texturefocus from solid red box to proper border
  - Was: <texturefocus border="3" colordiffuse="FFFF0000">colors/white.png</texturefocus>
  - Now: <texturefocus border="3">borders/border-focus.png</texturefocus>
  - Uses existing border texture instead of filled white texture with red tint
- This fixes red box appearing instead of red border on focus

Date Formatting:
- Updated info_window_helper.py to format premiered date using Kodi's regional date format
- Converts ISO date (2008-01-20) to user's preferred format (e.g., 20/01/2008 or 01/20/2008)
- Uses xbmc.getRegion('dateshort') to get user's date format preference
- Falls back to ISO format if conversion fails

IMDb Rating on Home Pages:
- Plugin already sets ListItem.Property(IMDbRating) on line 924 of addon.py
- Home.xml visibility conditions already check for this property
- Should display correctly on home pages

https://claude.ai/code/session_01TEQeZb4iSRKUTTdbQo1Pcy