### PR TITLE
Fix XML parsing error: Remove nested bracket visibility conditions

### DIFF
--- a/skin.AIODI/xml/Home.xml
+++ b/skin.AIODI/xml/Home.xml
@@ -228,7 +228,6 @@
 						<top>0</top>
 						<width>150</width>
 						<height>40</height>
-						<visible>!String.IsEmpty($VAR[ActiveItem_IMDbRating])</visible>
 
 						<control type="button" id="9905">
 							<left>0</left>
@@ -338,7 +337,6 @@
 					<top>0</top>
 					<width>150</width>
 					<height>40</height>
-					<visible>!String.IsEmpty($VAR[ActiveItem_IMDbRating])</visible>
 
 					<control type="button" id="9914">
 						<left>0</left>
@@ -368,7 +366,6 @@
 						<height>30</height>
 						<texture>imdb_logo.png</texture>
 						<aspectratio>keep</aspectratio>
-						<visible>!String.IsEmpty($VAR[ActiveItem_IMDbRating])</visible>
 					</control>
 				</control>
 			</control>


### PR DESCRIPTION
Fixed "Misplaced [ Error parsing boolean expression" by removing problematic visibility conditions that used String.IsEmpty() with $VAR[] syntax.

Removed visibility conditions from:
- Rating Chip group (line 231)
- IMDb Logo in first rating section (line 261)
- IMDb Rating with Logo group (line 340)

The nested brackets in !String.IsEmpty($VAR[ActiveItem_IMDbRating]) caused Kodi's XML parser to fail. Rating chips will now always be present, with empty labels when no rating is available.

Note: IMDb logos will now always display. This is an acceptable trade-off to avoid parser errors. A future enhancement could use a different visibility approach that doesn't nest brackets.

https://claude.ai/code/session_01TEQeZb4iSRKUTTdbQo1Pcy