### PR TITLE
Add debug logging to diagnose IMDb ID detection issue

### DIFF
--- a/plugin.video.aiostreams/addon.py
+++ b/plugin.video.aiostreams/addon.py
@@ -5228,6 +5228,7 @@ def action_info(params):
         window = xbmcgui.Window(10000)
         window.setProperty('InfoWindow.IsCustom', 'true')
         window.setProperty('InfoWindow.IMDB', meta_id)
+        xbmc.log(f'[AIOStreams] action_info: Set InfoWindow.IsCustom=true, InfoWindow.IMDB={meta_id}', xbmc.LOGWARNING)
         window.setProperty('InfoWindow.Title', meta.get('name', ''))
         window.setProperty('InfoWindow.Plot', meta.get('description', ''))
         window.setProperty('InfoWindow.Year', str(meta.get('year', '')))

--- a/skin.AIODI/resources/lib/info_window_helper.py
+++ b/skin.AIODI/resources/lib/info_window_helper.py
@@ -12,8 +12,7 @@ import time
 
 
 def log(msg, level=xbmc.LOGINFO):
-    if level in [xbmc.LOGERROR, xbmc.LOGWARNING]:
-        xbmc.log(f'[AIOStreams] {msg}', level)
+    xbmc.log(f'[info_window_helper] {msg}', level)
 
 
 def populate_cast_properties(content_type=None):
@@ -24,7 +23,10 @@ def populate_cast_properties(content_type=None):
         log('Starting cast property population')
 
         # Check if this is a custom info window (opened from plugin action)
-        is_custom = xbmc.getInfoLabel('Window(Home).Property(InfoWindow.IsCustom)') == 'true'
+        custom_flag = xbmc.getInfoLabel('Window(Home).Property(InfoWindow.IsCustom)')
+        log(f'InfoWindow.IsCustom property value: "{custom_flag}"', xbmc.LOGWARNING)
+        is_custom = custom_flag == 'true'
+        log(f'Custom mode detected: {is_custom}', xbmc.LOGWARNING)
 
         if is_custom:
             # Use Window Properties set by plugin


### PR DESCRIPTION
Added explicit WARNING-level logging to track:
- InfoWindow.IsCustom property value when info window opens
- Whether custom mode is detected (true/false)
- When action_info sets InfoWindow properties

Also fixed info_window_helper log function to output all messages, not just warnings/errors, to capture full execution flow.

This will help diagnose why cast and related items aren't populating from Next Up list and why search results show "No IMDb ID found" errors.

https://claude.ai/code/session_01UWQZSFh1KwdRrwMnkUwc92