### PR TITLE
Remove excess debug logging

### DIFF
--- a/plugin.video.aiostreams/addon.py
+++ b/plugin.video.aiostreams/addon.py
@@ -5228,7 +5228,6 @@ def action_info(params):
         window = xbmcgui.Window(10000)
         window.setProperty('InfoWindow.IsCustom', 'true')
         window.setProperty('InfoWindow.IMDB', meta_id)
-        xbmc.log(f'[AIOStreams] action_info: Set InfoWindow.IsCustom=true, InfoWindow.IMDB={meta_id}', xbmc.LOGWARNING)
         window.setProperty('InfoWindow.Title', meta.get('name', ''))
         window.setProperty('InfoWindow.Plot', meta.get('description', ''))
         window.setProperty('InfoWindow.Year', str(meta.get('year', '')))


### PR DESCRIPTION
Cleaned up debug logging added during troubleshooting:
- Restored info_window_helper log function to only output warnings/errors
- Removed explicit WARNING logs for InfoWindow.IsCustom detection
- Removed detailed ListItem property logging
- Removed INFO level logs throughout cast/metadata population
- Removed WARNING log from addon.py action_info function

Kept only ERROR and WARNING level logs for actual issues.

https://claude.ai/code/session_01UWQZSFh1KwdRrwMnkUwc92