### PR TITLE
fix: improve AIOStreams stream compatibility

### DIFF
--- a/plugin.video.aiostreams/addon.py
+++ b/plugin.video.aiostreams/addon.py
@@ -24,6 +24,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 try:
     # Essential imports only
     from resources.lib import ui_helpers, settings_helpers, constants, filters, cache, streams
+    from resources.lib.stream_utils import canonical_episode_id, canonical_meta_id, normalize_streams
     from resources.lib.globals import g
     from resources.lib.router import get_router, action, dispatch, set_default
     
@@ -224,8 +225,8 @@ def make_request(url, error_message='Request failed', cache_key=None):
         xbmcgui.Dialog().notification('AIOStreams', 'Request timed out', xbmcgui.NOTIFICATION_ERROR)
         return None
     except requests.RequestException as e:
-        xbmcgui.Dialog().notification('AIOStreams', f'{error_message}: {str(e)}', xbmcgui.NOTIFICATION_ERROR)
-        xbmc.log(f'[AIOStreams] Request error: {str(e)}', xbmc.LOGERROR)
+        xbmcgui.Dialog().notification('AIOStreams', error_message, xbmcgui.NOTIFICATION_ERROR)
+        xbmc.log(f'[AIOStreams] Request error: {type(e).__name__}', xbmc.LOGERROR)
         return None
     except ValueError:
         xbmcgui.Dialog().notification('AIOStreams', 'Invalid JSON response', xbmcgui.NOTIFICATION_ERROR)
@@ -367,12 +368,41 @@ def search_catalog(query, content_type='movie', skip=0):
 def get_streams(content_type, media_id):
     """Fetch streams for a given media ID."""
     base_url = get_base_url()
+    if not base_url:
+        xbmc.log('[AIOStreams] Cannot request streams: no configured base URL', xbmc.LOGERROR)
+        return None
     url = f"{base_url}/stream/{content_type}/{media_id}.json"
-    xbmc.log(f'[AIOStreams] Requesting streams from: {url}', xbmc.LOGDEBUG)
+    xbmc.log(f'[AIOStreams] Requesting streams: type={content_type}, id={media_id}', xbmc.LOGINFO)
     result = make_request(url, 'Stream error')
     if result:
-        xbmc.log(f'[AIOStreams] Received {len(result.get("streams", []))} streams for {media_id}', xbmc.LOGDEBUG)
+        normalized = normalize_streams(result.get('streams', []))
+        result['streams'] = normalized['playable']
+        result['_stream_summary'] = normalized
+        counts = ', '.join(f'{kind}={count}' for kind, count in sorted(normalized['counts'].items())) or 'none'
+        xbmc.log(
+            f'[AIOStreams] Stream response: type={content_type}, id={media_id}, '
+            f'total={sum(normalized["counts"].values())}, playable={len(normalized["playable"])}, '
+            f'transports=({counts})', xbmc.LOGINFO)
+        settings_helpers.log_debug(f'Normalized stream response for type={content_type}, id={media_id}')
+        for message in normalized['messages']:
+            xbmc.log(f'[AIOStreams] Stream message: {message}', xbmc.LOGWARNING)
     return result
+
+
+def show_no_playable_streams(stream_data, resolve=False):
+    """Explain a direct-stream miss and fail an outstanding Kodi resolver."""
+    summary = (stream_data or {}).get('_stream_summary', {})
+    messages = summary.get('messages') or []
+    counts = summary.get('counts') or {}
+    unsupported = sum(count for kind, count in counts.items()
+                      if kind not in ('direct_url', 'synthetic_error', 'synthetic_statistic'))
+    message = messages[0] if messages else (
+        f'No direct streams available ({unsupported} unsupported transport entries)' if unsupported
+        else 'No direct streams available')
+    xbmc.log(f'[AIOStreams] No playable streams: {message}', xbmc.LOGWARNING)
+    xbmcgui.Dialog().notification('AIOStreams', message[:250], xbmcgui.NOTIFICATION_ERROR)
+    if resolve and HANDLE >= 0:
+        xbmcplugin.setResolvedUrl(HANDLE, False, xbmcgui.ListItem())
 
 
 def get_catalog(content_type, catalog_id, genre=None, skip=0):
@@ -426,7 +456,7 @@ def get_catalog(content_type, catalog_id, genre=None, skip=0):
     else:
         url = f"{url_parts[0]}.json"
 
-    xbmc.log(f'[AIOStreams] Requesting catalog from: {url}', xbmc.LOGDEBUG)
+    xbmc.log(f'[AIOStreams] Requesting catalog: type={content_type}, id={catalog_id}, skip={skip}', xbmc.LOGDEBUG)
     catalog = make_request(url, 'Catalog error')
 
     # Cache the result in both tiers
@@ -448,7 +478,7 @@ def get_subtitles(content_type, media_id):
     """Fetch subtitles for a given media ID."""
     base_url = get_base_url()
     url = f"{base_url}/subtitles/{content_type}/{media_id}.json"
-    xbmc.log(f'[AIOStreams] Requesting subtitles from: {url}', xbmc.LOGDEBUG)
+    xbmc.log(f'[AIOStreams] Requesting subtitles: type={content_type}, id={media_id}', xbmc.LOGDEBUG)
     return make_request(url, 'Subtitle error')
 
 
@@ -694,7 +724,7 @@ def get_meta(content_type, meta_id):
     # Cache miss, fetch from API
     base_url = get_base_url()
     url = f"{base_url}/meta/{content_type}/{meta_id}.json"
-    xbmc.log(f'[AIOStreams] Requesting meta from: {url}', xbmc.LOGDEBUG)
+    xbmc.log(f'[AIOStreams] Requesting metadata: type={content_type}, id={meta_id}', xbmc.LOGDEBUG)
     result = make_request(url, 'Meta error')
 
     # FALLBACK: If result is empty or missing rating, try the "master" token from the skin's fetch_cast script
@@ -1427,6 +1457,7 @@ def action_search(params=None):
     # Display results
     for meta in items:
         item_id = meta.get('id')
+        stream_id = canonical_meta_id(meta)
         item_type = meta.get('type', content_type)
 
         if item_type == 'series':
@@ -1463,7 +1494,7 @@ def action_search(params=None):
             poster = meta.get('poster', '')
             fanart = meta.get('background', '')
             clearlogo = meta.get('logo', '')
-            url = get_url(action='play', content_type='movie' if item_type == 'movie' else item_type, imdb_id=item_id, title=title, poster=poster, fanart=fanart, clearlogo=clearlogo)
+            url = get_url(action='play', content_type='movie' if item_type == 'movie' else item_type, imdb_id=stream_id, title=title, poster=poster, fanart=fanart, clearlogo=clearlogo)
             is_folder = False
 
         list_item = create_listitem_with_context(meta, item_type, url)
@@ -1566,7 +1597,7 @@ def search_all_results(query):
                 poster = meta.get('poster', '')
                 fanart = meta.get('background', '')
                 clearlogo = meta.get('logo', '')
-                url = get_url(action='play', content_type='movie', imdb_id=item_id, title=title, poster=poster, fanart=fanart, clearlogo=clearlogo)
+                url = get_url(action='play', content_type='movie', imdb_id=canonical_meta_id(meta), title=title, poster=poster, fanart=fanart, clearlogo=clearlogo)
                 list_item = create_listitem_with_context(meta, 'movie', url)
                 list_item.setProperty('IsPlayable', 'true')
                 xbmcplugin.addDirectoryItem(HANDLE, url, list_item, False)
@@ -1649,7 +1680,7 @@ def play(params=None):
     else:
         season = params.get('season')
         episode = params.get('episode')
-        media_id = f"{imdb_id}:{season}:{episode}"
+        media_id = params.get('media_id') or f"{imdb_id}:{season}:{episode}"
         title = params.get('title', f'S{season}E{episode}')
 
     # If metadata not provided in params, fetch it from API
@@ -1677,9 +1708,9 @@ def play(params=None):
         stream_data = get_streams(content_type, media_id)
         progress.update(75)
 
-        if not stream_data or 'streams' not in stream_data or len(stream_data['streams']) == 0:
+        if not stream_data or not stream_data.get('streams'):
             progress.close()
-            xbmcgui.Dialog().notification('AIOStreams', 'No streams available', xbmcgui.NOTIFICATION_ERROR)
+            show_no_playable_streams(stream_data, resolve=True)
             return
 
         # Check default_behavior setting
@@ -1709,7 +1740,7 @@ def play(params=None):
         # Otherwise, auto-play first stream
         progress.update(85, 'Preparing playback...')
         stream = stream_data['streams'][0]
-        stream_url = stream.get('url') or stream.get('externalUrl')
+        stream_url = stream.get('_playback_url', '')
 
         if not stream_url:
             progress.close()
@@ -1779,7 +1810,7 @@ def play(params=None):
             for s in stream_data['streams']:
                 # Save URL, title/name/info needed for playback
                 min_streams.append({
-                    'url': s.get('url') or s.get('externalUrl'),
+                    'url': s.get('_playback_url', ''),
                     'title': s.get('title', ''),
                     'source': s.get('source', '') 
                 })
@@ -1805,7 +1836,7 @@ def play(params=None):
         # If we have a valid HANDLE (called as a plugin source), we MUST use setResolvedUrl.
         # If we don't (called via RunScript or similar), we use xbmc.Player().play().
         if HANDLE >= 0:
-            xbmc.log(f'[AIOStreams] Resolving URL for playback (HANDLE={HANDLE}): {stream_url}', xbmc.LOGINFO)
+            xbmc.log(f'[AIOStreams] Resolving direct stream for playback (HANDLE={HANDLE})', xbmc.LOGINFO)
             list_item.setPath(stream_url)
             xbmcplugin.setResolvedUrl(HANDLE, True, list_item)
             
@@ -1820,7 +1851,7 @@ def play(params=None):
             import threading
             threading.Thread(target=trigger_monitoring, daemon=True).start()
         else:
-            xbmc.log(f'[AIOStreams] Initiating Player (HANDLE={HANDLE}): {stream_url}', xbmc.LOGINFO)
+            xbmc.log(f'[AIOStreams] Initiating direct stream player (HANDLE={HANDLE})', xbmc.LOGINFO)
             get_player().play(stream_url, list_item)
 
     except Exception as e:
@@ -1856,7 +1887,7 @@ def play_first():
     else:
         season = params.get('season')
         episode = params.get('episode')
-        media_id = f"{imdb_id}:{season}:{episode}"
+        media_id = params.get('media_id') or f"{imdb_id}:{season}:{episode}"
 
     # Show progress dialog while scraping streams
     progress = xbmcgui.DialogProgress()
@@ -1869,15 +1900,15 @@ def play_first():
         stream_data = get_streams(content_type, media_id)
         progress.update(75)
 
-        if not stream_data or 'streams' not in stream_data or len(stream_data['streams']) == 0:
+        if not stream_data or not stream_data.get('streams'):
             progress.close()
-            xbmcgui.Dialog().notification('AIOStreams', 'No streams available', xbmcgui.NOTIFICATION_ERROR)
+            show_no_playable_streams(stream_data, resolve=True)
             return
 
         # Always auto-play first stream (ignore default_behavior setting)
         progress.update(85, 'Preparing playback...')
         stream = stream_data['streams'][0]
-        stream_url = stream.get('url') or stream.get('externalUrl')
+        stream_url = stream.get('_playback_url', '')
 
         if not stream_url:
             progress.close()
@@ -2046,7 +2077,7 @@ def select_stream():
     else:
         season = params.get('season')
         episode = params.get('episode')
-        media_id = f"{imdb_id}:{season}:{episode}"
+        media_id = params.get('media_id') or f"{imdb_id}:{season}:{episode}"
 
     # Cancel Kodi's resolver state immediately to avoid modal dialog conflicts
     # TMDBHelper calls this as a resolver, but we need to show a dialog first
@@ -2096,8 +2127,8 @@ def select_stream():
     # "Activate of window refused because there are active modal dialogs"
     xbmc.sleep(200)
 
-    if not stream_data or 'streams' not in stream_data or len(stream_data['streams']) == 0:
-        xbmcgui.Dialog().notification('AIOStreams', 'No streams available', xbmcgui.NOTIFICATION_ERROR)
+    if not stream_data or not stream_data.get('streams'):
+        show_no_playable_streams(stream_data)
         return
 
     # Use stream manager for enhanced display (same as show_streams_dialog)
@@ -2172,7 +2203,7 @@ def select_stream():
 
     # Get selected stream
     stream = stream_data['streams'][selected]
-    stream_url = stream.get('url') or stream.get('externalUrl')
+    stream_url = stream.get('_playback_url', '')
 
     if not stream_url:
         xbmcgui.Dialog().notification('AIOStreams', 'No playable URL found', xbmcgui.NOTIFICATION_ERROR)
@@ -2411,6 +2442,7 @@ def browse_catalog():
     # Display catalog items
     for meta in catalog_data['metas']:
         item_id = meta.get('id')
+        stream_id = canonical_meta_id(meta)
         item_type = meta.get('type', content_type)
         
         # Determine if this is a series or movie
@@ -2422,7 +2454,7 @@ def browse_catalog():
             poster = meta.get('poster', '')
             fanart = meta.get('background', '')
             clearlogo = meta.get('logo', '')
-            url = get_url(action='play', content_type='movie', imdb_id=item_id, title=title, poster=poster, fanart=fanart, clearlogo=clearlogo)
+            url = get_url(action='play', content_type='movie', imdb_id=stream_id, title=title, poster=poster, fanart=fanart, clearlogo=clearlogo)
             is_folder = False
 
         list_item = create_listitem_with_context(meta, content_type, url)
@@ -2482,8 +2514,8 @@ def show_streams():
     finally:
         progress.close()
 
-    if not stream_data or 'streams' not in stream_data or len(stream_data['streams']) == 0:
-        xbmcgui.Dialog().notification('AIOStreams', 'No streams available', xbmcgui.NOTIFICATION_ERROR)
+    if not stream_data or not stream_data.get('streams'):
+        show_no_playable_streams(stream_data)
         xbmcplugin.endOfDirectory(HANDLE, succeeded=False)
         return
 
@@ -2615,7 +2647,7 @@ def play_stream_by_index(content_type, media_id, stream_data, index, use_player=
         return False
 
     stream = stream_data['streams'][index]
-    stream_url = stream.get('url') or stream.get('externalUrl')
+    stream_url = stream.get('_playback_url', '')
 
     if not stream_url:
         xbmcgui.Dialog().notification('AIOStreams', 'No playable URL found', xbmcgui.NOTIFICATION_ERROR)
@@ -2675,8 +2707,6 @@ def play_stream_by_index(content_type, media_id, stream_data, index, use_player=
                 pass
             
             get_player().set_media_info('episode', episode_imdb_id, season, episode)
-            
-            get_player().set_media_info('episode', episode_imdb_id, season, episode)
         else:
             get_player().set_media_info('movie', media_id, None, None)
 
@@ -2684,13 +2714,17 @@ def play_stream_by_index(content_type, media_id, stream_data, index, use_player=
     if use_player:
         # Called from RunPlugin context (e.g., "Scrape Streams" context menu)
         # Use direct playback
-        xbmc.log(f'[AIOStreams] Starting direct playback: {stream_url}', xbmc.LOGINFO)
+        xbmc.log('[AIOStreams] Starting selected direct stream', xbmc.LOGINFO)
         player = xbmc.Player()
         player.play(stream_url, list_item)
     else:
         # Called from playable listitem context (e.g., clicking a movie/episode)
         # Use setResolvedUrl
         xbmcplugin.setResolvedUrl(HANDLE, True, list_item)
+        # Playback begins only after this plugin invocation returns. The player
+        # monitor owns any later success confirmation; handing Kodi a URL is not
+        # itself a successful playback.
+        return True
 
     # Monitor playback with 30 second timeout
     playback_started = False
@@ -2701,7 +2735,7 @@ def play_stream_by_index(content_type, media_id, stream_data, index, use_player=
     for i in range(300):  # 300 * 0.1 = 30 seconds
         if monitor.abortRequested():
             return False
-        if player.isPlaying():
+        if player.isPlayingVideo():
             playback_started = True
             break
         monitor.waitForAbort(0.1)
@@ -3231,7 +3265,7 @@ def show_episodes():
 
         # Add episode context menu
         episode_title = f'{series_name} - S{season:02d}E{episode_num:02d}'
-        episode_media_id = f"{meta_id}:{season}:{episode_num}"
+        episode_media_id = canonical_episode_id(episode, canonical_meta_id(meta) or meta_id, season, episode_num)
         episode_poster = meta.get('poster', '')
         episode_fanart = meta.get('background', '')
         episode_clearlogo = meta.get('logo', '')
@@ -3252,7 +3286,9 @@ def show_episodes():
         list_item.addContextMenuItems(context_menu)
 
         # Make episodes directly playable
-        url = get_url(action='play', content_type='series', imdb_id=meta_id, season=season, episode=episode_num, title=episode_title, poster=episode_poster, fanart=episode_fanart, clearlogo=episode_clearlogo)
+        url = get_url(action='play', content_type='series', imdb_id=canonical_meta_id(meta) or meta_id,
+                      media_id=episode_media_id, season=season, episode=episode_num, title=episode_title,
+                      poster=episode_poster, fanart=episode_fanart, clearlogo=episode_clearlogo)
         list_item.setProperty('IsPlayable', 'true')
         xbmcplugin.addDirectoryItem(HANDLE, url, list_item, False)
     
@@ -3469,7 +3505,7 @@ def trakt_watchlist(params=None):
             url = get_url(action='show_seasons', meta_id=item_id)
             is_folder = True
         else:
-            url = get_url(action='play', content_type='movie', imdb_id=item_id, title=meta.get('name', ''), 
+            url = get_url(action='play', content_type='movie', imdb_id=canonical_meta_id(meta), title=meta.get('name', ''),
                          poster=meta.get('poster', ''), fanart=meta.get('background', ''), clearlogo=meta.get('logo', ''))
             is_folder = False
 
@@ -3827,7 +3863,7 @@ def show_related():
             poster = meta.get('poster', '')
             fanart = meta.get('background', '')
             clearlogo = meta.get('logo', '')
-            url = get_url(action='play', content_type='movie', imdb_id=item_id, title=title, poster=poster, fanart=fanart, clearlogo=clearlogo)
+            url = get_url(action='play', content_type='movie', imdb_id=canonical_meta_id(meta), title=title, poster=poster, fanart=fanart, clearlogo=clearlogo)
             is_folder = False
 
         list_item = create_listitem_with_context(meta, item_content_type, url)
@@ -4972,7 +5008,7 @@ def smart_widget():
                         url = get_url(action='show_seasons', meta_id=item_id)
                         is_folder = True
                     else:
-                        url = get_url(action='show_streams', content_type='movie', media_id=item_id,
+                        url = get_url(action='show_streams', content_type='movie', media_id=canonical_meta_id(merged_meta),
                                     title=merged_meta.get('name', ''), poster=merged_meta.get('poster', ''),
                                     fanart=merged_meta.get('background', ''), clearlogo=merged_meta.get('logo', ''))
                         is_folder = False
@@ -5097,7 +5133,7 @@ def configured_widget():
                         url = get_url(action='show_seasons', meta_id=item_id)
                         is_folder = True
                     else:
-                        url = get_url(action='show_streams', content_type='movie', media_id=item_id,
+                        url = get_url(action='show_streams', content_type='movie', media_id=canonical_meta_id(meta),
                                      title=meta.get('name', ''), poster=meta.get('poster', ''),
                                      fanart=meta.get('background', ''), clearlogo=meta.get('logo', ''))
                         is_folder = False
@@ -5457,4 +5493,3 @@ if __name__ == '__main__':
             g.deinit()
         except:
             pass
-

--- a/plugin.video.aiostreams/addon.py
+++ b/plugin.video.aiostreams/addon.py
@@ -25,7 +25,8 @@ try:
     # Essential imports only
     from resources.lib import ui_helpers, settings_helpers, constants, filters, cache, streams
     from resources.lib.stream_utils import (
-        canonical_episode_id, canonical_meta_id, matching_episode_id, normalize_streams,
+        canonical_episode_id, canonical_meta_id, client_user_agent, matching_episode_id,
+        normalize_streams,
     )
     from resources.lib.globals import g
     from resources.lib.router import get_router, action, dispatch, set_default
@@ -171,7 +172,7 @@ def make_request(url, error_message='Request failed', cache_key=None):
     Returns:
         JSON response data, or cached data on 304, or None on error
     """
-    headers = {}
+    headers = {'User-Agent': client_user_agent(ADDON.getAddonInfo('version'))}
 
     # Check for cached ETag/Last-Modified headers to enable conditional requests
     if cache_key and HAS_MODULES:

--- a/plugin.video.aiostreams/addon.py
+++ b/plugin.video.aiostreams/addon.py
@@ -24,7 +24,9 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 try:
     # Essential imports only
     from resources.lib import ui_helpers, settings_helpers, constants, filters, cache, streams
-    from resources.lib.stream_utils import canonical_episode_id, canonical_meta_id, normalize_streams
+    from resources.lib.stream_utils import (
+        canonical_episode_id, canonical_meta_id, matching_episode_id, normalize_streams,
+    )
     from resources.lib.globals import g
     from resources.lib.router import get_router, action, dispatch, set_default
     
@@ -1682,13 +1684,23 @@ def play(params=None):
         episode = params.get('episode')
         media_id = params.get('media_id') or f"{imdb_id}:{season}:{episode}"
         title = params.get('title', f'S{season}E{episode}')
+    requested_media_id = media_id
 
-    # If metadata not provided in params, fetch it from API
-    if not poster or not fanart or not clearlogo:
+    # Full metadata often supplies the canonical IMDb/video ID even when catalog
+    # rows expose only a TMDB ID. Resolve it before making the stream request.
+    needs_canonical_id = not params.get('media_id') and not imdb_id.startswith('tt')
+    if not poster or not fanart or not clearlogo or needs_canonical_id:
         xbmc.log(f'[AIOStreams] play() fetching metadata for {imdb_id} (poster={bool(poster)}, fanart={bool(fanart)}, clearlogo={bool(clearlogo)})', xbmc.LOGINFO)
         meta_data = get_meta(content_type, imdb_id)
         if meta_data and 'meta' in meta_data:
             meta = meta_data['meta']
+            canonical_id = canonical_meta_id(meta) or imdb_id
+            if content_type == 'movie':
+                media_id = canonical_id
+            elif not params.get('media_id'):
+                media_id = matching_episode_id(meta, canonical_id, season, episode)
+            if media_id != requested_media_id:
+                xbmc.log(f'[AIOStreams] Resolved canonical stream ID: type={content_type}, id={media_id}', xbmc.LOGINFO)
             if not poster:
                 poster = meta.get('poster', '')
             if not fanart:

--- a/plugin.video.aiostreams/resources/lib/gui/windows/multiline_source_select.py
+++ b/plugin.video.aiostreams/resources/lib/gui/windows/multiline_source_select.py
@@ -10,7 +10,7 @@ import xbmc
 import xbmcgui
 import xbmcaddon
 import xbmcvfs
-from ...stream_utils import display_label
+from ...stream_utils import display_label, stream_display_fields
 
 
 # Control IDs matching the XML skin
@@ -312,6 +312,10 @@ class MultiLineSourceSelect(xbmcgui.WindowXML):
                 # AIOStreams formatters may distribute fields across both strings.
                 parse_text = '\n'.join(filter(None, (name, description, f'FILENAME: {filename}' if filename else '')))
                 fields = self._parse_stream_fields(parse_text)
+                structured_fields = stream_display_fields(stream)
+                for key, value in structured_fields.items():
+                    if not fields.get(key) and value:
+                        fields[key] = value
                 if not any(fields.values()):
                     fields['resolution'] = 'STREAM'
                     fields['filename'] = ' — '.join(filter(None, (name, description)))

--- a/plugin.video.aiostreams/resources/lib/gui/windows/multiline_source_select.py
+++ b/plugin.video.aiostreams/resources/lib/gui/windows/multiline_source_select.py
@@ -10,6 +10,7 @@ import xbmc
 import xbmcgui
 import xbmcaddon
 import xbmcvfs
+from ...stream_utils import display_label
 
 
 # Control IDs matching the XML skin
@@ -300,15 +301,22 @@ class MultiLineSourceSelect(xbmcgui.WindowXML):
 
             for idx, stream in enumerate(self.streams):
                 # Get stream name and description
-                name = stream.get('name', stream.get('title', ''))
+                name = display_label(stream)
                 description = stream.get('description', '')
+                filename = (stream.get('behaviorHints') or {}).get('filename', '')
 
                 # Replace emojis with text equivalents for compatibility
                 name = replace_emojis(name)
                 description = replace_emojis(description)
 
-                # Parse fields from name (custom formatter format)
-                fields = self._parse_stream_fields(name)
+                # AIOStreams formatters may distribute fields across both strings.
+                parse_text = '\n'.join(filter(None, (name, description, f'FILENAME: {filename}' if filename else '')))
+                fields = self._parse_stream_fields(parse_text)
+                if not any(fields.values()):
+                    fields['resolution'] = 'STREAM'
+                    fields['filename'] = ' — '.join(filter(None, (name, description)))
+                elif not fields['filename']:
+                    fields['filename'] = filename or name
 
                 # Create list item
                 list_item = xbmcgui.ListItem(label=name)

--- a/plugin.video.aiostreams/resources/lib/network.py
+++ b/plugin.video.aiostreams/resources/lib/network.py
@@ -202,25 +202,25 @@ def make_request(url, method='GET', headers=None, data=None, json_data=None,
     except requests.Timeout:
         if notify_errors:
             xbmcgui.Dialog().notification('AIOStreams', 'Request timed out', xbmcgui.NOTIFICATION_ERROR)
-        xbmc.log(f'[AIOStreams] Request timeout: {url}', xbmc.LOGERROR)
+        xbmc.log('[AIOStreams] Request timeout', xbmc.LOGERROR)
         return None
 
     except requests.HTTPError as e:
         if notify_errors:
             xbmcgui.Dialog().notification('AIOStreams', f'{error_message}', xbmcgui.NOTIFICATION_ERROR)
-        xbmc.log(f'[AIOStreams] HTTP error: {e}', xbmc.LOGERROR)
+        xbmc.log(f'[AIOStreams] HTTP error: {type(e).__name__}', xbmc.LOGERROR)
         return None
 
     except requests.RequestException as e:
         if notify_errors:
             xbmcgui.Dialog().notification('AIOStreams', f'{error_message}', xbmcgui.NOTIFICATION_ERROR)
-        xbmc.log(f'[AIOStreams] Request error: {e}', xbmc.LOGERROR)
+        xbmc.log(f'[AIOStreams] Request error: {type(e).__name__}', xbmc.LOGERROR)
         return None
 
     except ValueError:
         if notify_errors:
             xbmcgui.Dialog().notification('AIOStreams', 'Invalid JSON response', xbmcgui.NOTIFICATION_ERROR)
-        xbmc.log(f'[AIOStreams] Invalid JSON from: {url}', xbmc.LOGERROR)
+        xbmc.log('[AIOStreams] Invalid JSON response', xbmc.LOGERROR)
         return None
 
 

--- a/plugin.video.aiostreams/resources/lib/providers/aiostreams.py
+++ b/plugin.video.aiostreams/resources/lib/providers/aiostreams.py
@@ -11,6 +11,7 @@ import xbmcgui
 
 from .base import BaseProvider
 from ..cache import get_cache, cached
+from ..stream_utils import client_user_agent
 
 
 class AIOStreamsProvider(BaseProvider):
@@ -97,7 +98,12 @@ class AIOStreamsProvider(BaseProvider):
         Returns:
             JSON response data, or None on error
         """
-        headers = {}
+        try:
+            import xbmcaddon
+            version = xbmcaddon.Addon().getAddonInfo('version')
+        except Exception:
+            version = 'unknown'
+        headers = {'User-Agent': client_user_agent(version)}
         cache = get_cache()
 
         # Check for cached ETag/Last-Modified for conditional requests

--- a/plugin.video.aiostreams/resources/lib/providers/aiostreams.py
+++ b/plugin.video.aiostreams/resources/lib/providers/aiostreams.py
@@ -146,7 +146,7 @@ class AIOStreamsProvider(BaseProvider):
             return None
         except requests.RequestException as e:
             xbmcgui.Dialog().notification('AIOStreams', f'{error_message}', xbmcgui.NOTIFICATION_ERROR)
-            self.log(f'Request error: {e}', xbmc.LOGERROR)
+            self.log(f'Request error: {type(e).__name__}', xbmc.LOGERROR)
             return None
         except ValueError:
             xbmcgui.Dialog().notification('AIOStreams', 'Invalid JSON response', xbmcgui.NOTIFICATION_ERROR)
@@ -226,7 +226,7 @@ class AIOStreamsProvider(BaseProvider):
             return None
 
         url = f"{base_url}/stream/{content_type}/{media_id}.json"
-        self.log(f'Requesting streams: {url}', xbmc.LOGINFO)
+        self.log(f'Requesting streams: type={content_type}, id={media_id}', xbmc.LOGINFO)
 
         result = self._make_request(url, 'Stream error')
 
@@ -316,7 +316,7 @@ class AIOStreamsProvider(BaseProvider):
         else:
             url = f"{url_parts[0]}.json"
 
-        self.log(f'Requesting catalog: {url}', xbmc.LOGINFO)
+        self.log(f'Requesting catalog: type={content_type}, id={catalog_id}, skip={skip}', xbmc.LOGINFO)
         catalog = self._make_request(url, 'Catalog error')
 
         if catalog:
@@ -356,7 +356,7 @@ class AIOStreamsProvider(BaseProvider):
 
         # Fetch from API
         url = f"{base_url}/meta/{content_type}/{meta_id}.json"
-        self.log(f'Requesting meta: {url}', xbmc.LOGINFO)
+        self.log(f'Requesting metadata: type={content_type}, id={meta_id}', xbmc.LOGINFO)
         result = self._make_request(url, 'Meta error')
 
         if result:
@@ -413,7 +413,7 @@ class AIOStreamsProvider(BaseProvider):
             return None
 
         url = f"{base_url}/subtitles/{content_type}/{media_id}.json"
-        self.log(f'Requesting subtitles: {url}', xbmc.LOGINFO)
+        self.log(f'Requesting subtitles: type={content_type}, id={media_id}', xbmc.LOGINFO)
         return self._make_request(url, 'Subtitle error')
 
     def test_connection(self):

--- a/plugin.video.aiostreams/resources/lib/settings_helpers.py
+++ b/plugin.video.aiostreams/resources/lib/settings_helpers.py
@@ -114,6 +114,13 @@ def get_debug_logging():
     return get_bool_setting('debug_logging', False)
 
 
+def log_debug(message):
+    """Emit add-on diagnostic details only when its debug setting is enabled."""
+    if get_debug_logging():
+        import xbmc
+        xbmc.log(f'[AIOStreams] {message}', xbmc.LOGDEBUG)
+
+
 # Profile settings
 def get_current_profile():
     """Get current Kodi profile name."""

--- a/plugin.video.aiostreams/resources/lib/stream_utils.py
+++ b/plugin.video.aiostreams/resources/lib/stream_utils.py
@@ -126,6 +126,7 @@ def _format_bytes(value):
 def stream_display_fields(stream):
     """Extract useful dialog fields from formatter text and structured data."""
     data = stream.get('streamData') or {}
+    parsed = data.get('parsedFile') or {}
     hints = stream.get('behaviorHints') or {}
     search_text = stream_search_text(stream)
     resolution_match = re.search(r'(?i)\b(4k|uhd|fhd|(?:2160|1440|1080|720|576|480|360)p)\b', search_text)
@@ -140,17 +141,28 @@ def stream_display_fields(stream):
         duration = f'{int(duration) // 3600}h {(int(duration) % 3600) // 60}m'
     else:
         duration = ''
+    def joined(*values):
+        result = []
+        for value in values:
+            candidates = value if isinstance(value, (list, tuple)) else [value]
+            for candidate in candidates:
+                if candidate and str(candidate) not in result:
+                    result.append(str(candidate))
+        return ' | '.join(result)
+
+    video = joined(parsed.get('quality'), parsed.get('encode'), parsed.get('visualTags'))
+    audio = joined(parsed.get('audioTags'), parsed.get('audioChannels'), parsed.get('languages'))
     return {
-        'resolution': resolution_match.group(1).upper() if resolution_match else '',
+        'resolution': str(parsed.get('resolution') or (resolution_match.group(1).upper() if resolution_match else '')),
         'service': str(service),
         'addon': str(data.get('addon') or ''),
         'size': _format_bytes(data.get('size')),
         'proxied': 'YES' if data.get('proxied') is True else ('NO' if data.get('proxied') is False else ''),
         'cached': cached,
         'in_library': 'YES' if data.get('library') is True else ('NO' if data.get('library') is False else ''),
-        'duration': duration,
-        'video': '',
-        'audio': '',
+        'duration': duration or 'N/A',
+        'video': video,
+        'audio': audio,
         'indexer': str(data.get('indexer') or ''),
         'filename': str(hints.get('filename') or data.get('filename') or ''),
     }

--- a/plugin.video.aiostreams/resources/lib/stream_utils.py
+++ b/plugin.video.aiostreams/resources/lib/stream_utils.py
@@ -153,7 +153,7 @@ def stream_display_fields(stream):
     video = joined(parsed.get('quality'), parsed.get('encode'), parsed.get('visualTags')) or 'Unknown'
     audio = joined(parsed.get('audioTags'), parsed.get('audioChannels'), parsed.get('languages')) or 'Unknown'
     return {
-        'resolution': str(parsed.get('resolution') or (resolution_match.group(1).upper() if resolution_match else '')),
+        'resolution': str(parsed.get('resolution') or (resolution_match.group(1).upper() if resolution_match else 'Unknown')),
         'service': str(service),
         'addon': str(data.get('addon') or ''),
         'size': _format_bytes(data.get('size')),

--- a/plugin.video.aiostreams/resources/lib/stream_utils.py
+++ b/plugin.video.aiostreams/resources/lib/stream_utils.py
@@ -160,7 +160,7 @@ def stream_display_fields(stream):
         'proxied': 'YES' if data.get('proxied') is True else ('NO' if data.get('proxied') is False else ''),
         'cached': cached,
         'in_library': 'YES' if data.get('library') is True else ('NO' if data.get('library') is False else ''),
-        'duration': duration or 'N/A',
+        'duration': duration,
         'video': video,
         'audio': audio,
         'indexer': str(data.get('indexer') or ''),

--- a/plugin.video.aiostreams/resources/lib/stream_utils.py
+++ b/plugin.video.aiostreams/resources/lib/stream_utils.py
@@ -14,6 +14,11 @@ USENET = 'usenet'
 UNKNOWN = 'unknown'
 
 
+def client_user_agent(version):
+    """Identify Kodi as an AIOStreams-compatible Stremio API client."""
+    return f'AIOStreams/Kodi-{version or "unknown"}'
+
+
 def canonical_meta_id(meta):
     """Prefer the Stremio-compatible IMDb ID when metadata supplies one."""
     return meta.get('imdb_id') or meta.get('imdbId') or meta.get('id') or ''

--- a/plugin.video.aiostreams/resources/lib/stream_utils.py
+++ b/plugin.video.aiostreams/resources/lib/stream_utils.py
@@ -1,0 +1,119 @@
+"""Pure helpers for Stremio stream identifiers and stream normalization."""
+from collections import Counter
+from urllib.parse import quote
+from urllib.parse import urlsplit
+
+
+DIRECT_URL = 'direct_url'
+SYNTHETIC_ERROR = 'synthetic_error'
+SYNTHETIC_STATISTIC = 'synthetic_statistic'
+EXTERNAL_URL = 'external_url'
+TORRENT = 'torrent'
+YOUTUBE = 'youtube'
+USENET = 'usenet'
+UNKNOWN = 'unknown'
+
+
+def canonical_meta_id(meta):
+    """Prefer the Stremio-compatible IMDb ID when metadata supplies one."""
+    return meta.get('imdb_id') or meta.get('imdbId') or meta.get('id') or ''
+
+
+def canonical_episode_id(video, show_id, season, episode):
+    """Preserve an episode's exact Stremio video ID, with a legacy fallback."""
+    return video.get('id') or f'{show_id}:{season}:{episode}'
+
+
+def _text(value):
+    return value.strip() if isinstance(value, str) else ''
+
+
+def classify_stream(stream):
+    """Return the transport/synthetic class for a Stremio stream object."""
+    stream_data = stream.get('streamData') or {}
+    stream_type = _text(stream_data.get('type')).lower()
+    if stream_type == 'error' or stream_data.get('error'):
+        return SYNTHETIC_ERROR
+    if stream_type in ('statistic', 'statistics'):
+        return SYNTHETIC_STATISTIC
+    url = _text(stream.get('url'))
+    if url:
+        return DIRECT_URL if urlsplit(url).scheme.lower() in ('http', 'https') else UNKNOWN
+    if _text(stream.get('infoHash')):
+        return TORRENT
+    if _text(stream.get('ytId')):
+        return YOUTUBE
+    if _text(stream.get('nzbUrl')):
+        return USENET
+    if _text(stream.get('externalUrl')):
+        return EXTERNAL_URL
+    return UNKNOWN
+
+
+def kodi_headers(stream):
+    """Encode behaviorHints proxy request headers using Kodi URL syntax."""
+    hints = stream.get('behaviorHints') or {}
+    headers = (hints.get('proxyHeaders') or {}).get('request') or {}
+    pairs = []
+    for key, value in headers.items():
+        if key and value is not None:
+            pairs.append(f'{quote(str(key), safe="-")}={quote(str(value), safe="")}')
+    return '&'.join(pairs)
+
+
+def playable_url(stream):
+    """Return a Kodi-ready direct URL; never promote externalUrl."""
+    if classify_stream(stream) != DIRECT_URL:
+        return ''
+    url = _text(stream.get('url'))
+    headers = kodi_headers(stream)
+    return f'{url}|{headers}' if headers else url
+
+
+def stream_search_text(stream):
+    """Combine formatter fields used for labels and quality detection."""
+    hints = stream.get('behaviorHints') or {}
+    return '\n'.join(filter(None, (
+        _text(stream.get('name')),
+        _text(stream.get('title')),
+        _text(stream.get('description')),
+        _text(hints.get('filename')),
+    )))
+
+
+def display_label(stream):
+    """Build a useful non-blank primary label without assuming a formatter."""
+    hints = stream.get('behaviorHints') or {}
+    return (_text(stream.get('name')) or _text(stream.get('title')) or
+            _text(hints.get('filename')) or _text(stream.get('description')) or
+            'Direct stream')
+
+
+def stream_message(stream):
+    """Extract a concise synthetic error/information message."""
+    stream_data = stream.get('streamData') or {}
+    title = display_label(stream)
+    error = stream_data.get('error')
+    if isinstance(error, dict):
+        error = error.get('message') or error.get('description') or error.get('name')
+    detail = (_text(stream.get('description')) or _text(error))
+    if detail and detail != title:
+        return f'{title}: {detail}'
+    return title
+
+
+def normalize_streams(raw_streams):
+    """Split direct playable streams from diagnostics and summarize transports."""
+    raw_streams = raw_streams or []
+    counts = Counter(classify_stream(stream) for stream in raw_streams)
+    playable = []
+    messages = []
+    for stream in raw_streams:
+        kind = classify_stream(stream)
+        if kind == DIRECT_URL:
+            normalized = dict(stream)
+            normalized['_playback_url'] = playable_url(stream)
+            playable.append(normalized)
+        elif kind in (SYNTHETIC_ERROR, SYNTHETIC_STATISTIC):
+            messages.append(stream_message(stream))
+    return {'playable': playable, 'counts': dict(counts), 'messages': messages}

--- a/plugin.video.aiostreams/resources/lib/stream_utils.py
+++ b/plugin.video.aiostreams/resources/lib/stream_utils.py
@@ -24,6 +24,22 @@ def canonical_episode_id(video, show_id, season, episode):
     return video.get('id') or f'{show_id}:{season}:{episode}'
 
 
+def matching_episode_id(meta, show_id, season, episode):
+    """Find and preserve the exact ID for a season/episode in full metadata."""
+    try:
+        wanted_season = int(season)
+        wanted_episode = int(episode)
+    except (TypeError, ValueError):
+        return f'{show_id}:{season}:{episode}'
+    for video in meta.get('videos') or []:
+        try:
+            if int(video.get('season')) == wanted_season and int(video.get('episode')) == wanted_episode:
+                return canonical_episode_id(video, show_id, season, episode)
+        except (TypeError, ValueError):
+            continue
+    return f'{show_id}:{season}:{episode}'
+
+
 def _text(value):
     return value.strip() if isinstance(value, str) else ''
 

--- a/plugin.video.aiostreams/resources/lib/stream_utils.py
+++ b/plugin.video.aiostreams/resources/lib/stream_utils.py
@@ -2,6 +2,7 @@
 from collections import Counter
 from urllib.parse import quote
 from urllib.parse import urlsplit
+import re
 
 
 DIRECT_URL = 'direct_url'
@@ -108,6 +109,51 @@ def display_label(stream):
     return (_text(stream.get('name')) or _text(stream.get('title')) or
             _text(hints.get('filename')) or _text(stream.get('description')) or
             'Direct stream')
+
+
+def _format_bytes(value):
+    try:
+        size = float(value)
+    except (TypeError, ValueError):
+        return ''
+    for unit in ('B', 'KB', 'MB', 'GB', 'TB'):
+        if size < 1024 or unit == 'TB':
+            return f'{size:.2f} {unit}' if unit in ('GB', 'TB') else f'{size:.0f} {unit}'
+        size /= 1024
+    return ''
+
+
+def stream_display_fields(stream):
+    """Extract useful dialog fields from formatter text and structured data."""
+    data = stream.get('streamData') or {}
+    hints = stream.get('behaviorHints') or {}
+    search_text = stream_search_text(stream)
+    resolution_match = re.search(r'(?i)\b(4k|uhd|fhd|(?:2160|1440|1080|720|576|480|360)p)\b', search_text)
+    service = data.get('service') or ''
+    cached = ''
+    if isinstance(service, dict):
+        cached_value = service.get('cached')
+        cached = 'YES' if cached_value is True else ('NO' if cached_value is False else '')
+        service = service.get('name') or service.get('id') or ''
+    duration = data.get('duration')
+    if isinstance(duration, (int, float)) and duration > 0:
+        duration = f'{int(duration) // 3600}h {(int(duration) % 3600) // 60}m'
+    else:
+        duration = ''
+    return {
+        'resolution': resolution_match.group(1).upper() if resolution_match else '',
+        'service': str(service),
+        'addon': str(data.get('addon') or ''),
+        'size': _format_bytes(data.get('size')),
+        'proxied': 'YES' if data.get('proxied') is True else ('NO' if data.get('proxied') is False else ''),
+        'cached': cached,
+        'in_library': 'YES' if data.get('library') is True else ('NO' if data.get('library') is False else ''),
+        'duration': duration,
+        'video': '',
+        'audio': '',
+        'indexer': str(data.get('indexer') or ''),
+        'filename': str(hints.get('filename') or data.get('filename') or ''),
+    }
 
 
 def stream_message(stream):

--- a/plugin.video.aiostreams/resources/lib/stream_utils.py
+++ b/plugin.video.aiostreams/resources/lib/stream_utils.py
@@ -150,8 +150,8 @@ def stream_display_fields(stream):
                     result.append(str(candidate))
         return ' | '.join(result)
 
-    video = joined(parsed.get('quality'), parsed.get('encode'), parsed.get('visualTags'))
-    audio = joined(parsed.get('audioTags'), parsed.get('audioChannels'), parsed.get('languages'))
+    video = joined(parsed.get('quality'), parsed.get('encode'), parsed.get('visualTags')) or 'Unknown'
+    audio = joined(parsed.get('audioTags'), parsed.get('audioChannels'), parsed.get('languages')) or 'Unknown'
     return {
         'resolution': str(parsed.get('resolution') or (resolution_match.group(1).upper() if resolution_match else '')),
         'service': str(service),

--- a/plugin.video.aiostreams/resources/lib/streams.py
+++ b/plugin.video.aiostreams/resources/lib/streams.py
@@ -7,6 +7,7 @@ import xbmc
 import xbmcvfs
 from . import constants
 from . import settings_helpers
+from .stream_utils import display_label, stream_search_text
 
 
 class StreamManager:
@@ -67,7 +68,7 @@ class StreamManager:
         Detect quality from stream name.
         Returns tuple: (quality_key, quality_rank, quality_label)
         """
-        name_lower = stream_name.lower()
+        name_lower = (stream_name or '').lower()
 
         # Check for quality indicators
         for quality_key, rank in sorted(constants.QUALITY_RANKS.items(), key=lambda x: x[1], reverse=True):
@@ -101,8 +102,7 @@ class StreamManager:
         filtered = []
 
         for stream in streams:
-            stream_name = stream.get('name', stream.get('title', ''))
-            _, quality_rank, _ = self.detect_quality(stream_name)
+            _, quality_rank, _ = self.detect_quality(stream_search_text(stream))
 
             # Filter by minimum quality
             if quality_rank < min_rank:
@@ -168,7 +168,7 @@ class StreamManager:
         self.stats[stream_url]['last_used'] = int(time.time())
         self._save_stats()
 
-        xbmc.log(f'[AIOStreams] Stream result recorded: {stream_url[:50]}... = {success}', xbmc.LOGINFO)
+        xbmc.log(f'[AIOStreams] Stream result recorded: success={success}', xbmc.LOGINFO)
 
     def get_preference_score(self, stream_name):
         """Get preference score based on user's selection history."""
@@ -228,10 +228,10 @@ class StreamManager:
 
     def format_stream_title(self, stream):
         """Format stream title with quality badge."""
-        stream_name = stream.get('name', stream.get('title', 'Unknown Stream'))
+        stream_name = display_label(stream)
 
         # Detect quality
-        _, quality_rank, quality_label = self.detect_quality(stream_name)
+        _, quality_rank, quality_label = self.detect_quality(stream_search_text(stream))
         quality_color = self.get_quality_color(quality_rank)
 
         # Format title - Remove reliability icons for a cleaner presentation

--- a/plugin.video.aiostreams/resources/lib/web_config.py
+++ b/plugin.video.aiostreams/resources/lib/web_config.py
@@ -327,7 +327,7 @@ def configure_aiostreams(host_url=None):
 
             if clipboard_content and clipboard_content != last_clipboard:
                 last_clipboard = clipboard_content
-                xbmc.log(f'[AIOStreams WebConfig] Clipboard changed, checking: {clipboard_content[:50]}...', xbmc.LOGDEBUG)
+                xbmc.log('[AIOStreams WebConfig] Clipboard changed; checking configuration URL', xbmc.LOGDEBUG)
 
                 # Check if it's a valid manifest URL
                 if is_valid_manifest_url(clipboard_content):
@@ -337,7 +337,7 @@ def configure_aiostreams(host_url=None):
                     if manifest_url.startswith('stremio://'):
                         manifest_url = 'https://' + manifest_url[10:]
 
-                    xbmc.log(f'[AIOStreams WebConfig] Valid manifest URL detected: {manifest_url}', xbmc.LOGINFO)
+                    xbmc.log('[AIOStreams WebConfig] Valid manifest URL detected', xbmc.LOGINFO)
                     break
 
             # Sleep before next poll
@@ -387,7 +387,7 @@ def configure_aiostreams(host_url=None):
             3000
         )
 
-        xbmc.log(f'[AIOStreams WebConfig] Configuration saved: {manifest_url}', xbmc.LOGINFO)
+        xbmc.log('[AIOStreams WebConfig] Configuration saved', xbmc.LOGINFO)
         return manifest_url
 
     # No URL detected - offer manual entry
@@ -578,7 +578,7 @@ def retrieve_manifest():
 
         # Construct manifest URL with encrypted password
         manifest_url = f'{host_url}/stremio/{uuid_from_response}/{encrypted_password}/manifest.json'
-        xbmc.log(f'[AIOStreams WebConfig] Constructed manifest URL: {manifest_url[:50]}...', xbmc.LOGINFO)
+        xbmc.log('[AIOStreams WebConfig] Constructed manifest URL', xbmc.LOGINFO)
 
         # Save to settings
         addon.setSetting('base_url', manifest_url)

--- a/plugin.video.aiostreams/resources/skins/Default/1080i/aiostreams-source-select.xml
+++ b/plugin.video.aiostreams/resources/skins/Default/1080i/aiostreams-source-select.xml
@@ -57,7 +57,7 @@
                     <top>2</top>
                     <width>1028</width>
                     <height>126</height>
-                    <texture colordiffuse="E6191919">colors/white.png</texture>
+                    <texture colordiffuse="FF161616">colors/white.png</texture>
                 </control>
                 <control type="image">
                     <left>220</left>
@@ -71,7 +71,7 @@
                     <top>2</top>
                     <width>216</width>
                     <height>126</height>
-                    <texture colordiffuse="E645101A">colors/white.png</texture>
+                    <texture colordiffuse="FF402027">colors/white.png</texture>
                 </control>
                 <control type="image">
                     <left>2</left>
@@ -119,7 +119,7 @@
                         <width>250</width>
                         <height>35</height>
                         <font>font10</font>
-                        <textcolor>grey</textcolor>
+                        <textcolor>white</textcolor>
                         <label>[COLOR white]SIZE[/COLOR]  $INFO[ListItem.Property(size)]</label>
                     </control>
                     <control type="label">
@@ -128,7 +128,7 @@
                         <width>180</width>
                         <height>35</height>
                         <font>font10</font>
-                        <textcolor>grey</textcolor>
+                        <textcolor>white</textcolor>
                         <label>[COLOR white]CACHED[/COLOR]  $INFO[ListItem.Property(cached)]</label>
                     </control>
                     <control type="label">
@@ -137,7 +137,7 @@
                         <width>180</width>
                         <height>35</height>
                         <font>font10</font>
-                        <textcolor>grey</textcolor>
+                        <textcolor>white</textcolor>
                         <label>[COLOR white]PROXY[/COLOR]  $INFO[ListItem.Property(proxied)]</label>
                     </control>
                     <control type="label">
@@ -146,7 +146,7 @@
                         <width>330</width>
                         <height>35</height>
                         <font>font10</font>
-                        <textcolor>grey</textcolor>
+                        <textcolor>white</textcolor>
                         <label>[COLOR white]LIBRARY[/COLOR]  $INFO[ListItem.Property(in_library)]</label>
                     </control>
                     <control type="label">
@@ -154,7 +154,7 @@
                         <width>490</width>
                         <height>35</height>
                         <font>font10</font>
-                        <textcolor>grey</textcolor>
+                        <textcolor>white</textcolor>
                         <label>[COLOR white]VIDEO[/COLOR]  $INFO[ListItem.Property(video)]</label>
                     </control>
                     <control type="label">
@@ -163,24 +163,24 @@
                         <width>470</width>
                         <height>35</height>
                         <font>font10</font>
-                        <textcolor>grey</textcolor>
+                        <textcolor>white</textcolor>
                         <label>[COLOR white]AUDIO[/COLOR]  $INFO[ListItem.Property(audio)]</label>
                     </control>
                     <control type="label">
                         <top>70</top>
-                        <width>300</width>
+                        <width>420</width>
                         <height>35</height>
                         <font>font10</font>
-                        <textcolor>grey</textcolor>
+                        <textcolor>white</textcolor>
                         <label>[COLOR white]INDEXER[/COLOR]  $INFO[ListItem.Property(indexer)]</label>
                     </control>
                     <control type="label">
-                        <left>310</left>
+                        <left>430</left>
                         <top>70</top>
-                        <width>660</width>
+                        <width>540</width>
                         <height>35</height>
                         <font>font10</font>
-                        <textcolor>grey</textcolor>
+                        <textcolor>white</textcolor>
                         <label>[COLOR white]FILE[/COLOR]  $INFO[ListItem.Property(filename)]</label>
                     </control>
                 </control>
@@ -192,28 +192,28 @@
                     <top>2</top>
                     <width>1028</width>
                     <height>126</height>
-                    <texture colordiffuse="burgundy">colors/white.png</texture>
+                    <texture colordiffuse="FF681522">colors/white.png</texture>
                 </control>
                 <control type="image">
                     <left>2</left>
                     <top>2</top>
                     <width>216</width>
                     <height>126</height>
-                    <texture colordiffuse="burgundy">colors/white.png</texture>
+                    <texture colordiffuse="FF8A1018">colors/white.png</texture>
                 </control>
                 <control type="image">
                     <left>2</left>
                     <top>2</top>
                     <width>216</width>
                     <height>126</height>
-                    <texture border="1" colordiffuse="glass_border">colors/white.png</texture>
+                    <texture border="1" colordiffuse="88FFFFFF">colors/white.png</texture>
                 </control>
                 <control type="image">
                     <left>2</left>
                     <top>2</top>
                     <width>216</width>
                     <height>126</height>
-                    <texture colordiffuse="ff800000">colors/white.png</texture>
+                    <texture colordiffuse="FF8A1018">colors/white.png</texture>
                 </control>
                 <control type="group">
                     <left>12</left>
@@ -303,16 +303,16 @@
                     </control>
                     <control type="label">
                         <top>70</top>
-                        <width>300</width>
+                        <width>420</width>
                         <height>35</height>
                         <font>font10</font>
                         <textcolor>white</textcolor>
                         <label>[COLOR gold]INDEXER[/COLOR]  $INFO[ListItem.Property(indexer)]</label>
                     </control>
                     <control type="label">
-                        <left>310</left>
+                        <left>430</left>
                         <top>70</top>
-                        <width>660</width>
+                        <width>540</width>
                         <height>35</height>
                         <font>font10</font>
                         <textcolor>white</textcolor>

--- a/plugin.video.aiostreams/resources/skins/Default/1080i/aiostreams-source-select.xml
+++ b/plugin.video.aiostreams/resources/skins/Default/1080i/aiostreams-source-select.xml
@@ -120,7 +120,7 @@
                         <height>35</height>
                         <font>font10</font>
                         <textcolor>grey</textcolor>
-                        <label>[COLOR white]SIZE:[/COLOR] $INFO[ListItem.Property(size)]  •  [COLOR white]PROXIED:[/COLOR] $INFO[ListItem.Property(proxied)]  •  [COLOR white]CACHED:[/COLOR] $INFO[ListItem.Property(cached)]  •  [COLOR white]IN LIBRARY:[/COLOR] $INFO[ListItem.Property(in_library)]  •  [COLOR white]DURATION:[/COLOR] $INFO[ListItem.Property(duration)]</label>
+                        <label>[COLOR white]SIZE:[/COLOR] $INFO[ListItem.Property(size)]  •  [COLOR white]PROXIED:[/COLOR] $INFO[ListItem.Property(proxied)]  •  [COLOR white]CACHED:[/COLOR] $INFO[ListItem.Property(cached)]  •  [COLOR white]IN LIBRARY:[/COLOR] $INFO[ListItem.Property(in_library)]</label>
                     </control>
                     <control type="label">
                         <top>35</top>
@@ -210,7 +210,7 @@
                         <height>35</height>
                         <font>font10</font>
                         <textcolor>white</textcolor>
-                        <label>[COLOR gold]SIZE:[/COLOR] $INFO[ListItem.Property(size)]  •  [COLOR gold]PROXIED:[/COLOR] $INFO[ListItem.Property(proxied)]  •  [COLOR gold]CACHED:[/COLOR] $INFO[ListItem.Property(cached)]  •  [COLOR gold]IN LIBRARY:[/COLOR] $INFO[ListItem.Property(in_library)]  •  [COLOR gold]DURATION:[/COLOR] $INFO[ListItem.Property(duration)]</label>
+                        <label>[COLOR gold]SIZE:[/COLOR] $INFO[ListItem.Property(size)]  •  [COLOR gold]PROXIED:[/COLOR] $INFO[ListItem.Property(proxied)]  •  [COLOR gold]CACHED:[/COLOR] $INFO[ListItem.Property(cached)]  •  [COLOR gold]IN LIBRARY:[/COLOR] $INFO[ListItem.Property(in_library)]</label>
                     </control>
                     <control type="label">
                         <top>35</top>

--- a/plugin.video.aiostreams/resources/skins/Default/1080i/aiostreams-source-select.xml
+++ b/plugin.video.aiostreams/resources/skins/Default/1080i/aiostreams-source-select.xml
@@ -116,27 +116,72 @@
                     <top>12</top>
                     <control type="label">
                         <top>0</top>
-                        <width>990</width>
+                        <width>250</width>
                         <height>35</height>
                         <font>font10</font>
                         <textcolor>grey</textcolor>
-                        <label>[COLOR white]SIZE:[/COLOR] $INFO[ListItem.Property(size)]  •  [COLOR white]PROXIED:[/COLOR] $INFO[ListItem.Property(proxied)]  •  [COLOR white]CACHED:[/COLOR] $INFO[ListItem.Property(cached)]  •  [COLOR white]IN LIBRARY:[/COLOR] $INFO[ListItem.Property(in_library)]</label>
+                        <label>[COLOR white]SIZE[/COLOR]  $INFO[ListItem.Property(size)]</label>
+                    </control>
+                    <control type="label">
+                        <left>260</left>
+                        <top>0</top>
+                        <width>180</width>
+                        <height>35</height>
+                        <font>font10</font>
+                        <textcolor>grey</textcolor>
+                        <label>[COLOR white]CACHED[/COLOR]  $INFO[ListItem.Property(cached)]</label>
+                    </control>
+                    <control type="label">
+                        <left>450</left>
+                        <top>0</top>
+                        <width>180</width>
+                        <height>35</height>
+                        <font>font10</font>
+                        <textcolor>grey</textcolor>
+                        <label>[COLOR white]PROXY[/COLOR]  $INFO[ListItem.Property(proxied)]</label>
+                    </control>
+                    <control type="label">
+                        <left>640</left>
+                        <top>0</top>
+                        <width>330</width>
+                        <height>35</height>
+                        <font>font10</font>
+                        <textcolor>grey</textcolor>
+                        <label>[COLOR white]LIBRARY[/COLOR]  $INFO[ListItem.Property(in_library)]</label>
                     </control>
                     <control type="label">
                         <top>35</top>
-                        <width>990</width>
+                        <width>490</width>
                         <height>35</height>
                         <font>font10</font>
                         <textcolor>grey</textcolor>
-                        <label>[COLOR white]VIDEO:[/COLOR] $INFO[ListItem.Property(video)]  •  [COLOR white]AUDIO:[/COLOR] $INFO[ListItem.Property(audio)]  •  [COLOR white]INDEXER:[/COLOR] $INFO[ListItem.Property(indexer)]</label>
+                        <label>[COLOR white]VIDEO[/COLOR]  $INFO[ListItem.Property(video)]</label>
+                    </control>
+                    <control type="label">
+                        <left>500</left>
+                        <top>35</top>
+                        <width>470</width>
+                        <height>35</height>
+                        <font>font10</font>
+                        <textcolor>grey</textcolor>
+                        <label>[COLOR white]AUDIO[/COLOR]  $INFO[ListItem.Property(audio)]</label>
                     </control>
                     <control type="label">
                         <top>70</top>
-                        <width>990</width>
+                        <width>300</width>
                         <height>35</height>
                         <font>font10</font>
                         <textcolor>grey</textcolor>
-                        <label>[COLOR white]FILENAME:[/COLOR] $INFO[ListItem.Property(filename)]</label>
+                        <label>[COLOR white]INDEXER[/COLOR]  $INFO[ListItem.Property(indexer)]</label>
+                    </control>
+                    <control type="label">
+                        <left>310</left>
+                        <top>70</top>
+                        <width>660</width>
+                        <height>35</height>
+                        <font>font10</font>
+                        <textcolor>grey</textcolor>
+                        <label>[COLOR white]FILE[/COLOR]  $INFO[ListItem.Property(filename)]</label>
                     </control>
                 </control>
             </itemlayout>
@@ -206,28 +251,73 @@
                     <top>12</top>
                     <control type="label">
                         <top>0</top>
-                        <width>990</width>
+                        <width>250</width>
                         <height>35</height>
                         <font>font10</font>
                         <textcolor>white</textcolor>
-                        <label>[COLOR gold]SIZE:[/COLOR] $INFO[ListItem.Property(size)]  •  [COLOR gold]PROXIED:[/COLOR] $INFO[ListItem.Property(proxied)]  •  [COLOR gold]CACHED:[/COLOR] $INFO[ListItem.Property(cached)]  •  [COLOR gold]IN LIBRARY:[/COLOR] $INFO[ListItem.Property(in_library)]</label>
+                        <label>[COLOR gold]SIZE[/COLOR]  $INFO[ListItem.Property(size)]</label>
+                    </control>
+                    <control type="label">
+                        <left>260</left>
+                        <top>0</top>
+                        <width>180</width>
+                        <height>35</height>
+                        <font>font10</font>
+                        <textcolor>white</textcolor>
+                        <label>[COLOR gold]CACHED[/COLOR]  $INFO[ListItem.Property(cached)]</label>
+                    </control>
+                    <control type="label">
+                        <left>450</left>
+                        <top>0</top>
+                        <width>180</width>
+                        <height>35</height>
+                        <font>font10</font>
+                        <textcolor>white</textcolor>
+                        <label>[COLOR gold]PROXY[/COLOR]  $INFO[ListItem.Property(proxied)]</label>
+                    </control>
+                    <control type="label">
+                        <left>640</left>
+                        <top>0</top>
+                        <width>330</width>
+                        <height>35</height>
+                        <font>font10</font>
+                        <textcolor>white</textcolor>
+                        <label>[COLOR gold]LIBRARY[/COLOR]  $INFO[ListItem.Property(in_library)]</label>
                     </control>
                     <control type="label">
                         <top>35</top>
-                        <width>990</width>
+                        <width>490</width>
                         <height>35</height>
                         <font>font10</font>
                         <textcolor>white</textcolor>
-                        <label>[COLOR gold]VIDEO:[/COLOR] $INFO[ListItem.Property(video)]  •  [COLOR gold]AUDIO:[/COLOR] $INFO[ListItem.Property(audio)]  •  [COLOR gold]INDEXER:[/COLOR] $INFO[ListItem.Property(indexer)]</label>
+                        <label>[COLOR gold]VIDEO[/COLOR]  $INFO[ListItem.Property(video)]</label>
+                    </control>
+                    <control type="label">
+                        <left>500</left>
+                        <top>35</top>
+                        <width>470</width>
+                        <height>35</height>
+                        <font>font10</font>
+                        <textcolor>white</textcolor>
+                        <label>[COLOR gold]AUDIO[/COLOR]  $INFO[ListItem.Property(audio)]</label>
                     </control>
                     <control type="label">
                         <top>70</top>
-                        <width>990</width>
+                        <width>300</width>
+                        <height>35</height>
+                        <font>font10</font>
+                        <textcolor>white</textcolor>
+                        <label>[COLOR gold]INDEXER[/COLOR]  $INFO[ListItem.Property(indexer)]</label>
+                    </control>
+                    <control type="label">
+                        <left>310</left>
+                        <top>70</top>
+                        <width>660</width>
                         <height>35</height>
                         <font>font10</font>
                         <textcolor>white</textcolor>
                         <scroll>true</scroll>
-                        <label>[COLOR gold]FILENAME:[/COLOR] $INFO[ListItem.Property(filename)]</label>
+                        <label>[COLOR gold]FILE[/COLOR]  $INFO[ListItem.Property(filename)]</label>
                     </control>
                 </control>
             </focusedlayout>

--- a/plugin.video.aiostreams/resources/skins/Default/1080i/aiostreams-source-select.xml
+++ b/plugin.video.aiostreams/resources/skins/Default/1080i/aiostreams-source-select.xml
@@ -57,28 +57,28 @@
                     <top>2</top>
                     <width>1028</width>
                     <height>126</height>
-                    <texture colordiffuse="glass_bg">colors/white.png</texture>
+                    <texture colordiffuse="E6191919">colors/white.png</texture>
                 </control>
                 <control type="image">
                     <left>220</left>
                     <top>2</top>
                     <width>1028</width>
                     <height>126</height>
-                    <texture border="1" colordiffuse="glass_border">colors/white.png</texture>
+                    <texture border="1" colordiffuse="55FFFFFF">colors/white.png</texture>
                 </control>
                 <control type="image">
                     <left>2</left>
                     <top>2</top>
                     <width>216</width>
                     <height>126</height>
-                    <texture colordiffuse="burgundy_bg">colors/white.png</texture>
+                    <texture colordiffuse="E645101A">colors/white.png</texture>
                 </control>
                 <control type="image">
                     <left>2</left>
                     <top>2</top>
                     <width>216</width>
                     <height>126</height>
-                    <texture border="1" colordiffuse="glass_border">colors/white.png</texture>
+                    <texture border="1" colordiffuse="55FFFFFF">colors/white.png</texture>
                 </control>
                 <control type="group">
                     <left>12</left>
@@ -88,6 +88,7 @@
                         <width>200</width>
                         <height>50</height>
                         <font>font13</font>
+                        <textcolor>white</textcolor>
                         <align>left</align>
                         <label>$INFO[ListItem.Property(resolution)]</label>
                     </control>
@@ -96,6 +97,7 @@
                         <width>200</width>
                         <height>30</height>
                         <font>font10</font>
+                        <textcolor>white</textcolor>
                         <align>left</align>
                         <label>$INFO[ListItem.Property(service)]</label>
                     </control>
@@ -104,6 +106,7 @@
                         <width>200</width>
                         <height>30</height>
                         <font>font10</font>
+                        <textcolor>white</textcolor>
                         <align>left</align>
                         <label>$INFO[ListItem.Property(addon)]</label>
                     </control>

--- a/tests/test_stream_utils.py
+++ b/tests/test_stream_utils.py
@@ -101,6 +101,11 @@ class StreamUtilsTests(unittest.TestCase):
         self.assertEqual('DD | 5.1 | English', fields['audio'])
         self.assertEqual('Movie.2026.1080p.mkv', fields['filename'])
 
+    def test_missing_media_details_are_explicit(self):
+        fields = stream_display_fields({'name': 'FHD', 'streamData': {}})
+        self.assertEqual('Unknown', fields['video'])
+        self.assertEqual('Unknown', fields['audio'])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_stream_utils.py
+++ b/tests/test_stream_utils.py
@@ -96,7 +96,7 @@ class StreamUtilsTests(unittest.TestCase):
         self.assertEqual('Comet', fields['addon'])
         self.assertEqual('8.00 GB', fields['size'])
         self.assertEqual('YES', fields['cached'])
-        self.assertEqual('N/A', fields['duration'])
+        self.assertEqual('', fields['duration'])
         self.assertEqual('BluRay | HEVC | IMAX', fields['video'])
         self.assertEqual('DD | 5.1 | English', fields['audio'])
         self.assertEqual('Movie.2026.1080p.mkv', fields['filename'])

--- a/tests/test_stream_utils.py
+++ b/tests/test_stream_utils.py
@@ -10,7 +10,7 @@ from resources.lib.stream_utils import (  # noqa: E402
     DIRECT_URL, EXTERNAL_URL, SYNTHETIC_ERROR, SYNTHETIC_STATISTIC,
     TORRENT, UNKNOWN, USENET, YOUTUBE, canonical_episode_id,
     canonical_meta_id, classify_stream, client_user_agent, display_label, kodi_headers,
-    matching_episode_id,
+    matching_episode_id, stream_display_fields,
     normalize_streams, playable_url, stream_search_text,
 )
 
@@ -74,6 +74,24 @@ class StreamUtilsTests(unittest.TestCase):
         self.assertEqual('Movie.4K.mkv', display_label(stream))
         self.assertIn('2160p', stream_search_text(stream))
         self.assertIn('Movie.4K.mkv', stream_search_text(stream))
+
+    def test_structured_display_fields(self):
+        stream = {
+            'name': 'FHD',
+            'behaviorHints': {'filename': 'Movie.2026.1080p.mkv'},
+            'streamData': {
+                'service': {'id': 'debridge', 'cached': True},
+                'addon': 'Comet', 'size': 8 * 1024 ** 3, 'proxied': False,
+                'library': False, 'indexer': 'ExampleIndexer',
+            },
+        }
+        fields = stream_display_fields(stream)
+        self.assertEqual('FHD', fields['resolution'])
+        self.assertEqual('debridge', fields['service'])
+        self.assertEqual('Comet', fields['addon'])
+        self.assertEqual('8.00 GB', fields['size'])
+        self.assertEqual('YES', fields['cached'])
+        self.assertEqual('Movie.2026.1080p.mkv', fields['filename'])
 
 
 if __name__ == '__main__':

--- a/tests/test_stream_utils.py
+++ b/tests/test_stream_utils.py
@@ -1,0 +1,70 @@
+import os
+import sys
+import unittest
+
+
+ROOT = os.path.dirname(os.path.dirname(__file__))
+sys.path.insert(0, os.path.join(ROOT, 'plugin.video.aiostreams'))
+
+from resources.lib.stream_utils import (  # noqa: E402
+    DIRECT_URL, EXTERNAL_URL, SYNTHETIC_ERROR, SYNTHETIC_STATISTIC,
+    TORRENT, UNKNOWN, USENET, YOUTUBE, canonical_episode_id,
+    canonical_meta_id, classify_stream, display_label, kodi_headers,
+    normalize_streams, playable_url, stream_search_text,
+)
+
+
+class StreamUtilsTests(unittest.TestCase):
+    def test_synthetic_entries_override_external_url(self):
+        self.assertEqual(SYNTHETIC_ERROR, classify_stream({
+            'externalUrl': 'https://example.invalid/project',
+            'streamData': {'type': 'error'},
+        }))
+        self.assertEqual(SYNTHETIC_STATISTIC, classify_stream({
+            'externalUrl': 'https://example.invalid/project',
+            'streamData': {'type': 'statistic'},
+        }))
+
+    def test_direct_url_and_external_url_are_distinct(self):
+        self.assertEqual(DIRECT_URL, classify_stream({'url': 'https://media.invalid/a.mkv'}))
+        self.assertEqual(EXTERNAL_URL, classify_stream({'externalUrl': 'https://example.invalid'}))
+        self.assertEqual('', playable_url({'externalUrl': 'https://example.invalid'}))
+        self.assertEqual(UNKNOWN, classify_stream({'url': 'magnet:?xt=urn:btih:abc'}))
+
+    def test_unsupported_transports_are_classified(self):
+        self.assertEqual(TORRENT, classify_stream({'infoHash': 'abc'}))
+        self.assertEqual(YOUTUBE, classify_stream({'ytId': 'abc'}))
+        self.assertEqual(USENET, classify_stream({'nzbUrl': 'https://x.invalid/a.nzb'}))
+        self.assertEqual(UNKNOWN, classify_stream({'name': 'mystery'}))
+
+    def test_proxy_request_headers_use_kodi_url_syntax(self):
+        stream = {'url': 'https://media.invalid/a', 'behaviorHints': {
+            'proxyHeaders': {'request': {'User-Agent': 'Kodi Test', 'Referer': 'https://ref.invalid/a b'}}}}
+        self.assertEqual('User-Agent=Kodi%20Test&Referer=https%3A%2F%2Fref.invalid%2Fa%20b', kodi_headers(stream))
+        self.assertTrue(playable_url(stream).startswith('https://media.invalid/a|User-Agent='))
+
+    def test_normalization_keeps_only_direct_urls_and_messages(self):
+        result = normalize_streams([
+            {'url': 'https://media.invalid/a'},
+            {'name': 'No streams', 'description': 'Provider failed', 'streamData': {'type': 'error'}},
+            {'externalUrl': 'https://example.invalid/project'},
+        ])
+        self.assertEqual(1, len(result['playable']))
+        self.assertEqual(['No streams: Provider failed'], result['messages'])
+        self.assertEqual(1, result['counts'][EXTERNAL_URL])
+
+    def test_identifier_selection(self):
+        self.assertEqual('tt123', canonical_meta_id({'id': 'tmdb:1', 'imdb_id': 'tt123'}))
+        self.assertEqual('tt456', canonical_meta_id({'id': 'tmdb:2', 'imdbId': 'tt456'}))
+        self.assertEqual('tmdb:1:1:1', canonical_episode_id({'id': 'tmdb:1:1:1'}, 'tt123', 1, 1))
+        self.assertEqual('tt123:1:1', canonical_episode_id({}, 'tt123', 1, 1))
+
+    def test_display_and_quality_text_fallbacks(self):
+        stream = {'description': 'Real Debrid 2160p', 'behaviorHints': {'filename': 'Movie.4K.mkv'}}
+        self.assertEqual('Movie.4K.mkv', display_label(stream))
+        self.assertIn('2160p', stream_search_text(stream))
+        self.assertIn('Movie.4K.mkv', stream_search_text(stream))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_stream_utils.py
+++ b/tests/test_stream_utils.py
@@ -102,7 +102,8 @@ class StreamUtilsTests(unittest.TestCase):
         self.assertEqual('Movie.2026.1080p.mkv', fields['filename'])
 
     def test_missing_media_details_are_explicit(self):
-        fields = stream_display_fields({'name': 'FHD', 'streamData': {}})
+        fields = stream_display_fields({'name': 'Direct stream', 'streamData': {}})
+        self.assertEqual('Unknown', fields['resolution'])
         self.assertEqual('Unknown', fields['video'])
         self.assertEqual('Unknown', fields['audio'])
 

--- a/tests/test_stream_utils.py
+++ b/tests/test_stream_utils.py
@@ -9,7 +9,7 @@ sys.path.insert(0, os.path.join(ROOT, 'plugin.video.aiostreams'))
 from resources.lib.stream_utils import (  # noqa: E402
     DIRECT_URL, EXTERNAL_URL, SYNTHETIC_ERROR, SYNTHETIC_STATISTIC,
     TORRENT, UNKNOWN, USENET, YOUTUBE, canonical_episode_id,
-    canonical_meta_id, classify_stream, display_label, kodi_headers,
+    canonical_meta_id, classify_stream, display_label, kodi_headers, matching_episode_id,
     normalize_streams, playable_url, stream_search_text,
 )
 
@@ -58,6 +58,12 @@ class StreamUtilsTests(unittest.TestCase):
         self.assertEqual('tt456', canonical_meta_id({'id': 'tmdb:2', 'imdbId': 'tt456'}))
         self.assertEqual('tmdb:1:1:1', canonical_episode_id({'id': 'tmdb:1:1:1'}, 'tt123', 1, 1))
         self.assertEqual('tt123:1:1', canonical_episode_id({}, 'tt123', 1, 1))
+        meta = {'videos': [
+            {'id': 'ignored', 'season': 1, 'episode': 2},
+            {'id': 'canonical-episode-id', 'season': 1, 'episode': 1},
+        ]}
+        self.assertEqual('canonical-episode-id', matching_episode_id(meta, 'tt123', '1', '1'))
+        self.assertEqual('tt123:2:3', matching_episode_id(meta, 'tt123', 2, 3))
 
     def test_display_and_quality_text_fallbacks(self):
         stream = {'description': 'Real Debrid 2160p', 'behaviorHints': {'filename': 'Movie.4K.mkv'}}

--- a/tests/test_stream_utils.py
+++ b/tests/test_stream_utils.py
@@ -9,12 +9,16 @@ sys.path.insert(0, os.path.join(ROOT, 'plugin.video.aiostreams'))
 from resources.lib.stream_utils import (  # noqa: E402
     DIRECT_URL, EXTERNAL_URL, SYNTHETIC_ERROR, SYNTHETIC_STATISTIC,
     TORRENT, UNKNOWN, USENET, YOUTUBE, canonical_episode_id,
-    canonical_meta_id, classify_stream, display_label, kodi_headers, matching_episode_id,
+    canonical_meta_id, classify_stream, client_user_agent, display_label, kodi_headers,
+    matching_episode_id,
     normalize_streams, playable_url, stream_search_text,
 )
 
 
 class StreamUtilsTests(unittest.TestCase):
+    def test_client_identity_is_recognized_by_aiostreams(self):
+        self.assertEqual('AIOStreams/Kodi-1.2.3', client_user_agent('1.2.3'))
+
     def test_synthetic_entries_override_external_url(self):
         self.assertEqual(SYNTHETIC_ERROR, classify_stream({
             'externalUrl': 'https://example.invalid/project',

--- a/tests/test_stream_utils.py
+++ b/tests/test_stream_utils.py
@@ -83,14 +83,22 @@ class StreamUtilsTests(unittest.TestCase):
                 'service': {'id': 'debridge', 'cached': True},
                 'addon': 'Comet', 'size': 8 * 1024 ** 3, 'proxied': False,
                 'library': False, 'indexer': 'ExampleIndexer',
+                'parsedFile': {
+                    'resolution': '1080p', 'quality': 'BluRay', 'encode': 'HEVC',
+                    'visualTags': ['IMAX'], 'audioTags': ['DD'],
+                    'audioChannels': ['5.1'], 'languages': ['English'],
+                },
             },
         }
         fields = stream_display_fields(stream)
-        self.assertEqual('FHD', fields['resolution'])
+        self.assertEqual('1080p', fields['resolution'])
         self.assertEqual('debridge', fields['service'])
         self.assertEqual('Comet', fields['addon'])
         self.assertEqual('8.00 GB', fields['size'])
         self.assertEqual('YES', fields['cached'])
+        self.assertEqual('N/A', fields['duration'])
+        self.assertEqual('BluRay | HEVC | IMAX', fields['video'])
+        self.assertEqual('DD | 5.1 | English', fields['audio'])
         self.assertEqual('Movie.2026.1080p.mkv', fields['filename'])
 
 


### PR DESCRIPTION
## Summary

Fixes Kodi playback compatibility with current AIOStreams Stremio responses and makes the stream selector display useful, readable formatter details.

Fixes #281

- Reject synthetic AIOStreams error/statistics entries and arbitrary external URLs
- Classify unsupported transports instead of sending them blindly to Kodi
- Resolve canonical IMDb movie IDs from full metadata
- Preserve exact episode IDs from `meta.videos`
- Support direct HTTP(S) streams and Kodi proxy request headers
- Populate selector fields from `name`, `description`, `behaviorHints.filename`, and `streamData.parsedFile`
- Improve quality detection and selector layout, contrast, alignment, and fallbacks
- Avoid recording playback success before playback actually begins
- Redact private manifest and playback endpoints from logs
- Send an AIOStreams-compatible client identity so structured stream metadata is available

## Root causes

AIOStreams appends synthetic error and statistics objects whose `externalUrl` points to its GitHub project. The add-on treated `url` and `externalUrl` as interchangeable playable media, so a diagnostic entry could be selected and handed to Kodi as a video.

Catalog entries also commonly expose TMDB identifiers while stream requests require canonical IMDb identifiers. Episode playback reconstructed IDs rather than preserving the exact selected `meta.videos[].id`.

The custom selector assumed one colon-delimited formatter layout and parsed only `name`. Current AIOStreams responses distribute display data across formatter text, `behaviorHints.filename`, and structured `streamData`, which caused the blank rows reported in #281.

## Testing

Automated:

- 10 unit tests covering synthetic entries, transport classification, direct URLs, proxy headers, identifier selection, exact episode IDs, display fallbacks, quality metadata, and structured selector fields
- Full Python syntax compilation
- Selector XML parsing
- `git diff --check`
- Diff reviewed for credentials and private URLs

Manual Kodi Flatpak testing:

- Oppenheimer resolved from `tmdb:872585` to `tt15398776`
- Direct movie streams displayed and played successfully
- Yellowstone S01E01 requested `tt4236770:1:1`
- Direct episode streams displayed and played successfully
- Synthetic errors displayed contextually and were never treated as media
- Stream rows verified readable with populated size, cache, proxy, library, video, audio, indexer, service, add-on, and filename details
- Missing parsed resolution/video/audio values display as `Unknown`

## Limitations

- Torrent, YouTube, Usenet/archive, external browser URLs, and unknown transports are reported or skipped. This change intentionally supports direct HTTP(S) playback first.
- ElfCache/Comet upstream deadlines are controlled within AIOStreams and can expire before Kodi's configured HTTP timeout.
- Duration is omitted because AIOStreams commonly returns `0`; probing every candidate URL would slow selection and could consume debrid resources.
- Video/audio fields show only attributes that AIOStreams can parse reliably, otherwise `Unknown`.
